### PR TITLE
Make btdb plugin python2 & python3 compatible

### DIFF
--- a/nova/engines/btdb.py
+++ b/nova/engines/btdb.py
@@ -1,4 +1,4 @@
-#VERSION: 1.04
+#VERSION: 1.05
 # AUTHORS: Charles Worthing
 # CONTRIBUTORS: Diego de las Heras (ngosang@hotmail.es)
 
@@ -26,8 +26,14 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from HTMLParser import HTMLParser
-# qBt
+try:
+    # python3
+    from html.parser import HTMLParser
+except ImportError:
+    # python2
+    from HTMLParser import HTMLParser
+
+#qBt
 from novaprinter import prettyPrinter
 from helpers import download_file, retrieve_url
 

--- a/nova/engines/versions.txt
+++ b/nova/engines/versions.txt
@@ -1,4 +1,4 @@
-btdb: 1.04
+btdb: 1.05
 eztv: 1.01
 jackett: 2.00
 leetx: 2.00

--- a/nova3/engines/btdb.py
+++ b/nova3/engines/btdb.py
@@ -1,4 +1,4 @@
-#VERSION: 1.04
+#VERSION: 1.05
 # AUTHORS: Charles Worthing
 # CONTRIBUTORS: Diego de las Heras (ngosang@hotmail.es)
 
@@ -26,8 +26,14 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from html.parser import HTMLParser
-# qBt
+try:
+    # python3
+    from html.parser import HTMLParser
+except ImportError:
+    # python2
+    from HTMLParser import HTMLParser
+
+#qBt
 from novaprinter import prettyPrinter
 from helpers import download_file, retrieve_url
 

--- a/nova3/engines/versions.txt
+++ b/nova3/engines/versions.txt
@@ -1,4 +1,4 @@
-btdb: 1.04
+btdb: 1.05
 eztv: 1.01
 jackett: 2.00
 leetx: 2.00


### PR DESCRIPTION
So the files are the same. It's easy to maintain, like other plugins.
No need to increase version, is only cosmetic.