### PR TITLE
Modified btdb.py to capture seeds and leeches.

### DIFF
--- a/nova/engines/btdb.py
+++ b/nova/engines/btdb.py
@@ -1,4 +1,4 @@
-#VERSION: 1.10
+#VERSION: 1.11
 # AUTHORS: Charles Worthing
 # CONTRIBUTORS: Diego de las Heras (ngosang@hotmail.es)
 
@@ -107,8 +107,8 @@ class btdb(object):
                     self.current_item["engine_url"] = self.url
                     self.current_item["link"] = self.magnet_link
                     self.current_item["desc_link"] = self.desc_link
-                    self.current_item["seeds"] = -1
-                    self.current_item["leech"] = -1
+                    self.current_item["seeds"] = self.meta_data_array[6]
+                    self.current_item["leech"] = self.meta_data_array[8]
 
                     prettyPrinter(self.current_item)
                     self.results.append('a')

--- a/nova3/engines/btdb.py
+++ b/nova3/engines/btdb.py
@@ -1,4 +1,4 @@
-#VERSION: 1.10
+#VERSION: 1.11
 # AUTHORS: Charles Worthing
 # CONTRIBUTORS: Diego de las Heras (ngosang@hotmail.es)
 
@@ -107,8 +107,8 @@ class btdb(object):
                     self.current_item["engine_url"] = self.url
                     self.current_item["link"] = self.magnet_link
                     self.current_item["desc_link"] = self.desc_link
-                    self.current_item["seeds"] = -1
-                    self.current_item["leech"] = -1
+                    self.current_item["seeds"] = self.meta_data_array[6]
+                    self.current_item["leech"] = self.meta_data_array[8]
 
                     prettyPrinter(self.current_item)
                     self.results.append('a')


### PR DESCRIPTION
btdb.py collects the seeds and leeches from btdb.eu but does not add
them to the dict used by prettyPrinter. This change does so.

The unused popularity is actually the number of seeds on the websites. The number of leeches on the website is collected but not used in the prettyPrinter dict. I collect it here and leave it for prettyPrinter to display.