### PR TITLE
Parsing xml with utf-8 encoding

### DIFF
--- a/nova/engines/jackett.py
+++ b/nova/engines/jackett.py
@@ -110,7 +110,7 @@ class jackett(object):
             return
 
         # process search results
-        response_xml = xml.etree.ElementTree.fromstring(response)
+        response_xml = xml.etree.ElementTree.fromstring(response.encode('utf-8'))
         for result in response_xml.find('channel').findall('item'):
             res = {}
 


### PR DESCRIPTION
xml.etree.ElementTree.fromstring doesn't work with UTF-8 XMLs without encoding the response first in python 2