### PR TITLE
Drop leading zero ('0') from plugin minor version

### DIFF
--- a/nova/engines/jackett.py
+++ b/nova/engines/jackett.py
@@ -1,4 +1,4 @@
-#VERSION: 3.03
+#VERSION: 3.4
 # AUTHORS: Diego de las Heras (ngosang@hotmail.es)
 # CONTRIBUTORS: ukharley
 #               hannsen (github.com/hannsen)

--- a/nova/engines/leetx.py
+++ b/nova/engines/leetx.py
@@ -1,4 +1,4 @@
-#VERSION: 2.01
+#VERSION: 2.2
 #AUTHORS: Vikas Yadav (https://github.com/v1k45 | http://v1k45.com)
 #CONTRIBUTORS: Diego de las Heras (ngosang@hotmail.es)
 

--- a/nova/engines/legittorrents.py
+++ b/nova/engines/legittorrents.py
@@ -1,4 +1,4 @@
-#VERSION: 2.03
+#VERSION: 2.4
 # AUTHORS: Christophe Dumez (chris@qbittorrent.org)
 #          Douman (custparasite@gmx.se)
 

--- a/nova/engines/limetorrents.py
+++ b/nova/engines/limetorrents.py
@@ -1,4 +1,4 @@
-#VERSION: 4.04
+#VERSION: 4.5
 # AUTHORS: Lima66
 # CONTRIBUTORS: Diego de las Heras (ngosang@hotmail.es)
 

--- a/nova/engines/versions.txt
+++ b/nova/engines/versions.txt
@@ -1,8 +1,8 @@
 eztv: 1.10
-jackett: 3.03
-leetx: 2.01
-legittorrents: 2.03
-limetorrents: 4.04
+jackett: 3.4
+leetx: 2.2
+legittorrents: 2.4
+limetorrents: 4.5
 piratebay: 2.20
 rarbg: 2.12
 torlock: 2.1

--- a/nova3/engines/jackett.py
+++ b/nova3/engines/jackett.py
@@ -1,4 +1,4 @@
-#VERSION: 3.03
+#VERSION: 3.4
 # AUTHORS: Diego de las Heras (ngosang@hotmail.es)
 # CONTRIBUTORS: ukharley
 #               hannsen (github.com/hannsen)

--- a/nova3/engines/leetx.py
+++ b/nova3/engines/leetx.py
@@ -1,4 +1,4 @@
-#VERSION: 2.01
+#VERSION: 2.2
 #AUTHORS: Vikas Yadav (https://github.com/v1k45 | http://v1k45.com)
 #CONTRIBUTORS: Diego de las Heras (ngosang@hotmail.es)
 

--- a/nova3/engines/legittorrents.py
+++ b/nova3/engines/legittorrents.py
@@ -1,4 +1,4 @@
-#VERSION: 2.03
+#VERSION: 2.4
 # AUTHORS: Christophe Dumez (chris@qbittorrent.org)
 #          Douman (custparasite@gmx.se)
 

--- a/nova3/engines/limetorrents.py
+++ b/nova3/engines/limetorrents.py
@@ -1,4 +1,4 @@
-#VERSION: 4.04
+#VERSION: 4.5
 # AUTHORS: Lima66
 # CONTRIBUTORS: Diego de las Heras (ngosang@hotmail.es)
 

--- a/nova3/engines/versions.txt
+++ b/nova3/engines/versions.txt
@@ -1,8 +1,8 @@
 eztv: 1.10
-jackett: 3.03
-leetx: 2.01
-legittorrents: 2.03
-limetorrents: 4.04
+jackett: 3.4
+leetx: 2.2
+legittorrents: 2.4
+limetorrents: 4.5
 piratebay: 2.20
 rarbg: 2.12
 torlock: 2.1


### PR DESCRIPTION
Four search plugins specify a leading zero in their minor version (e.g. `jackett: 3.03`). This leading zero isn't reflected in the qBittorrent GUI or the Web UI. This is because qBittorrent's version display logic [0] effectively drops the leading zero when calling `QString::number()`. Given that semver rule 2 [1] expressely forbids leading zeros, I don't consider qBittorrent's implementation a bug. Thus, we might as well drop the leading zero from those version numbers.

[0] https://github.com/qbittorrent/qBittorrent/blob/8999f1a8daaf293480bb5c6dd36a4a6c260adecb/src/base/utils/version.h#L115,L129
[1] https://semver.org/#spec-item-2