### PR TITLE
Updated travis.yml to add Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - python: 3.6
     - python: 3.7
     - python: 3.8
+    - python: 3.9
     - python: nightly
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,13 @@ matrix:
   include:
     - python: 3.5
     - python: 3.6
+    - python: 3.6-dev
     - python: 3.7
+    - python: 3.7-dev
     - python: 3.8
+    - python: 3.8-dev
     - python: 3.9
+    - python: 3.9-dev
     - python: nightly
 
 install:


### PR DESCRIPTION
Python now has a version 3.9 that should be tested against during CI.