### PR TITLE
[Jackett] Add User Agent header while making API call.

### DIFF
--- a/nova3/engines/jackett.py
+++ b/nova3/engines/jackett.py
@@ -208,7 +208,10 @@ class jackett(object):
             # we can't use helpers.retrieve_url because of redirects
             # we need the cookie processor to handle redirects
             opener = urllib_request.build_opener(urllib_request.HTTPCookieProcessor(CookieJar()))
-            response = opener.open(query).read().decode('utf-8')
+            request = urllib_request.Request(query, headers={
+                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36 Edg/113.0.1774.57'
+            })
+            response = opener.open(request).read().decode('utf-8')
         except urllib_request.HTTPError as e:
             # if the page returns a magnet redirect, used in download_torrent
             if e.code == 302:


### PR DESCRIPTION
Latest Jackett versions throw 403 Forbidden if a fake User Agent is not set.