### PR TITLE
Add published date to PirateBay results

### DIFF
--- a/nova3/engines/piratebay.py
+++ b/nova3/engines/piratebay.py
@@ -1,4 +1,4 @@
-#VERSION: 3.2
+#VERSION: 3.3
 # AUTHORS: Fabien Devaux (fab@gnux.info)
 # CONTRIBUTORS: Christophe Dumez (chris@qbittorrent.org)
 #               Arthur (custparasite@gmx.se)
@@ -88,7 +88,8 @@ class piratebay(object):
                 'seeds': result['seeders'],
                 'leech': result['leechers'],
                 'engine_url': self.url,
-                'desc_link': self.url + '/description.php?id=' + result['id']
+                'desc_link': self.url + '/description.php?id=' + result['id'],
+                'pub_date': result['added'],
             }
             prettyPrinter(res)
 

--- a/nova3/engines/versions.txt
+++ b/nova3/engines/versions.txt
@@ -1,7 +1,7 @@
 eztv: 1.14
 jackett: 4.0
 limetorrents: 4.7
-piratebay: 3.2
+piratebay: 3.3
 solidtorrents: 2.1
 torlock: 2.22
 torrentproject: 1.2


### PR DESCRIPTION
This PR adds the date field to the results from the piratebay.py plugin.

It is meant to go with the recently merged PR: https://github.com/qbittorrent/qBittorrent/pull/20703

The change does _not_ break compatibility with older (current) qBittorrent versions.

![image](https://github.com/qbittorrent/search-plugins/assets/13711380/0ad4ab51-f0b2-4b9a-9115-d490f7de4abe)
