### PR TITLE
Added published date to torrents-csv

### DIFF
--- a/nova3/engines/torrentscsv.py
+++ b/nova3/engines/torrentscsv.py
@@ -1,4 +1,4 @@
-#VERSION: 1.3
+#VERSION: 1.4
 # AUTHORS: Dessalines
 
 # Redistribution and use in source and binary forms, with or without
@@ -68,7 +68,8 @@ class torrentscsv(object):
                    'seeds': result['seeders'],
                    'leech': result['leechers'],
                    'engine_url': self.url,
-                   'desc_link': desc_url}
+                   'desc_link': desc_url,
+                   'pub_date': result['created_unix']}
             prettyPrinter(res)
 
     def download_link(self, result):

--- a/nova3/engines/versions.txt
+++ b/nova3/engines/versions.txt
@@ -5,4 +5,4 @@ piratebay: 3.3
 solidtorrents: 2.1
 torlock: 2.22
 torrentproject: 1.2
-torrentscsv: 1.3
+torrentscsv: 1.4


### PR DESCRIPTION
This adds the `pub_date` field to torrents-csv's results, allowing it to be displayed in a future version of qBittorrent.

As with my previous PR, I have confirmed that it does not break older/current qBittorrent versions!

![image](https://github.com/qbittorrent/search-plugins/assets/13711380/96e54491-afec-4ef6-aedf-e11270bf9b3e)
