### PR TITLE
Added published date to solidtorrents

### DIFF
--- a/nova3/engines/versions.txt
+++ b/nova3/engines/versions.txt
@@ -2,7 +2,7 @@ eztv: 1.14
 jackett: 4.0
 limetorrents: 4.7
 piratebay: 3.3
-solidtorrents: 2.2
+solidtorrents: 2.3
 torlock: 2.23
 torrentproject: 1.3
 torrentscsv: 1.4


### PR DESCRIPTION
This PR adds pub_date to the solidtorrents plugin.

Confirmed to work with nova2.py and my local build of qbittorrent.

![image](https://github.com/user-attachments/assets/c940f5c0-a8d8-404b-b2f9-92984975d25d)
