### PR TITLE
Fixed EZTV plugin

### DIFF
--- a/nova3/engines/eztv.py
+++ b/nova3/engines/eztv.py
@@ -1,4 +1,4 @@
-#VERSION: 1.14
+#VERSION: 1.15
 # AUTHORS: nindogo
 # CONTRIBUTORS: Diego de las Heras (ngosang@hotmail.es)
 
@@ -10,7 +10,7 @@ from helpers import retrieve_url
 
 class eztv(object):
     name = "EZTV"
-    url = 'https://eztv.re'
+    url = 'https://eztvx.to/'
     supported_categories = {'all': 'all', 'tv': 'tv'}
 
     class MyHtmlParser(HTMLParser):
@@ -61,7 +61,7 @@ class eztv(object):
 
     def search(self, what, cat='all'):
         query = self.url + '/search/' + what.replace('%20', '-')
-        eztv_html = retrieve_url(query)
+        eztv_html = retrieve_url(query, post_data=b"layout=def_wlinks")
 
         eztv_parser = self.MyHtmlParser(self.url)
         eztv_parser.feed(eztv_html)

--- a/nova3/engines/eztv.py
+++ b/nova3/engines/eztv.py
@@ -70,8 +70,6 @@ class eztv(object):
         except TypeError:
             # Older versions of retrieve_url did not support request_data/POST, se we must do the
             # request ourselves...
-            if not url.startswith("https://"): # Satisfy the linter
-                return ""
             user_agent = 'Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0'
             req = urllib.request.Request(url, data, {'User-Agent': user_agent})
             try:

--- a/nova3/engines/eztv.py
+++ b/nova3/engines/eztv.py
@@ -64,7 +64,7 @@ class eztv(object):
 
     def do_query(self, what):
         url = f"{self.url}/search/{what.replace('%20', '-')}"
-        data =b"layout=def_wlinks"
+        data = b"layout=def_wlinks"
         try:
             return retrieve_url(url, request_data=data)
         except TypeError:
@@ -73,7 +73,7 @@ class eztv(object):
             user_agent = 'Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0'
             req = urllib.request.Request(url, data, {'User-Agent': user_agent})
             try:
-                response = urllib.request.urlopen(req)
+                response = urllib.request.urlopen(req)  # nosec B310
                 return response.read().decode('utf-8')
             except urllib.error.URLError as errno:
                 print(f"Connection error: {errno.reason}")

--- a/nova3/engines/eztv.py
+++ b/nova3/engines/eztv.py
@@ -2,10 +2,47 @@
 # AUTHORS: nindogo
 # CONTRIBUTORS: Diego de las Heras (ngosang@hotmail.es)
 
+import io
+import gzip
+import urllib.error
+import urllib.parse
+import urllib.request
 from html.parser import HTMLParser
 
 from novaprinter import prettyPrinter
-from helpers import retrieve_url
+from helpers import htmlentitydecode
+
+# Some sites blocks default python User-agent
+headers = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0'}
+
+# We must implement our own retrieve_url because helpers.py versions prior to 1.49 did not 
+# support POST requests. That version is taken from helpers.py 1.45
+def retrieve_url(url, data=None):
+    """ Return the content of the url page as a string """
+    req = urllib.request.Request(url, data, headers)
+    try:
+        response = urllib.request.urlopen(req)
+    except urllib.error.URLError as errno:
+        print(" ".join(("Connection error:", str(errno.reason))))
+        return ""
+    dat = response.read()
+    # Check if it is gzipped
+    if dat[:2] == b'\x1f\x8b':
+        # Data is gzip encoded, decode it
+        compressedstream = io.BytesIO(dat)
+        gzipper = gzip.GzipFile(fileobj=compressedstream)
+        extracted_data = gzipper.read()
+        dat = extracted_data
+    info = response.info()
+    charset = 'utf-8'
+    try:
+        ignore, charset = info['Content-Type'].split('charset=')
+    except Exception:
+        pass
+    dat = dat.decode(charset, 'replace')
+    dat = htmlentitydecode(dat)
+    # return dat.encode('utf-8', 'replace')
+    return dat
 
 
 class eztv(object):
@@ -61,7 +98,7 @@ class eztv(object):
 
     def search(self, what, cat='all'):
         query = self.url + '/search/' + what.replace('%20', '-')
-        eztv_html = retrieve_url(query, post_data=b"layout=def_wlinks")
+        eztv_html = retrieve_url(query, b"layout=def_wlinks")
 
         eztv_parser = self.MyHtmlParser(self.url)
         eztv_parser.feed(eztv_html)

--- a/nova3/engines/eztv.py
+++ b/nova3/engines/eztv.py
@@ -70,10 +70,13 @@ class eztv(object):
         except TypeError:
             # Older versions of retrieve_url did not support request_data/POST, se we must do the
             # request ourselves...
+            if not url.startswith("https://"): # Satisfy the linter
+                return ""
             user_agent = 'Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0'
             req = urllib.request.Request(url, data, {'User-Agent': user_agent})
             try:
-                return urllib.request.urlopen(req).read().decode('utf-8')
+                response = urllib.request.urlopen(req)
+                return response.read().decode('utf-8')
             except urllib.error.URLError as errno:
                 print(f"Connection error: {errno.reason}")
             return ""

--- a/nova3/engines/versions.txt
+++ b/nova3/engines/versions.txt
@@ -1,4 +1,4 @@
-eztv: 1.14
+eztv: 1.15
 jackett: 4.0
 limetorrents: 4.7
 piratebay: 3.3


### PR DESCRIPTION
There's another PR to fix it, https://github.com/qbittorrent/search-plugins/pull/267, but keeping track of cookies and random user agent doesn't seem necessary for me. Maybe the protection kicks in when using a VPN?

In any case, there is now an additional requirement of also doing a POST to request links to be shown.

This PR adds that. <strike>It is dependant on this PR being accepted in qBittorrent: https://github.com/qbittorrent/qBittorrent/pull/21184

But, like #267, I can also bundle the patched retrieve_url with POST support in the plugin, so that it works for everybody...</strike>

I've updated the code to fall back to raw urllib, it should work regardless of the user's helpers.py version (or if the qbt PR is rejected).