### PR TITLE
Add date field to eztv

### DIFF
--- a/nova3/engines/versions.txt
+++ b/nova3/engines/versions.txt
@@ -1,4 +1,4 @@
-eztv: 1.14
+eztv: 1.16
 jackett: 4.0
 limetorrents: 4.7
 piratebay: 3.3


### PR DESCRIPTION
They don't provide a convenient format unfortunately, and my parsing might not be exhaustive.

It's also not very accurate when all you have to go by is "1 year [ago]".

But it's certainly better than nothing and seems to work well enough.

NOTE: This PR is branched off current master and doesn't directly depend on any other PR, but since eztv is currently broken then it's not terribly useful until either #291 or #267 is accepted.

![image](https://github.com/user-attachments/assets/5df991e6-db86-49a5-99a3-ac569be98107)
