### PR TITLE
Fixed search failure due to unexpected parser state

### DIFF
--- a/nova3/engines/limetorrents.py
+++ b/nova3/engines/limetorrents.py
@@ -1,4 +1,4 @@
-#VERSION: 4.7
+#VERSION: 4.8
 # AUTHORS: Lima66
 # CONTRIBUTORS: Diego de las Heras (ngosang@hotmail.es)
 
@@ -38,7 +38,7 @@ class limetorrents(object):
             self.url = url
             self.current_item = {}  # dict for found item
             self.item_name = None  # key's name in current_item dict
-            self.page_empty = 22000
+            self.page_items = 0
             self.inside_tr = False
             self.findTable = False
             self.parser_class = {"tdnormal": "size",  # class
@@ -113,14 +113,11 @@ class limetorrents(object):
         query = query.replace("%20", "-")
         category = self.supported_categories[cat]
 
-        parser = self.MyHtmlParser(self.url)
-        page = 1
-        while True:
-            page_url = "{0}/search/{1}/{2}/seeds/{3}/".format(self.url, category, query, page)
+        for page in range(1, 5):
+            page_url = f"{self.url}/search/{category}/{query}/seeds/{page}/"
             html = retrieve_url(page_url)
-            lunghezza_html = len(html)
-            if page > 6 or lunghezza_html <= parser.page_empty:
-                return
+            parser = self.MyHtmlParser(self.url)
             parser.feed(html)
-            page += 1
-        parser.close()
+            parser.close()
+            if parser.page_items < 20:
+                break

--- a/nova3/engines/torrentproject.py
+++ b/nova3/engines/torrentproject.py
@@ -1,4 +1,4 @@
-#VERSION: 1.4
+#VERSION: 1.5
 #AUTHORS: mauricci
 
 from helpers import retrieve_url
@@ -102,26 +102,18 @@ class torrentproject(object):
                             elif curr_key != 'name':
                                 self.singleResData[curr_key] += data.strip()
 
-        def feed(self, html):
-            HTMLParser.feed(self, html)
-            self.pageComplete = False
-            self.insideResults = False
-            self.insideDataDiv = False
-            self.spanCount = -1
-
     def search(self, what, cat='all'):
         # curr_cat = self.supported_categories[cat]
-        parser = self.MyHTMLParser(self.url)
         what = what.replace('%20', '+')
         # analyze first 5 pages of results
         for currPage in range(0, 5):
             url = self.url + '/browse?t={0}&p={1}'.format(what, currPage)
             html = retrieve_url(url)
+            parser = self.MyHTMLParser(self.url)
             parser.feed(html)
-            if len(parser.pageRes) <= 0:
+            parser.close()
+            if len(parser.pageRes) < 20:
                 break
-            del parser.pageRes[:]
-        parser.close()
 
     def download_torrent(self, info):
         """ Downloader """

--- a/nova3/engines/versions.txt
+++ b/nova3/engines/versions.txt
@@ -1,8 +1,8 @@
 eztv: 1.16
 jackett: 4.0
-limetorrents: 4.7
+limetorrents: 4.8
 piratebay: 3.3
-solidtorrents: 2.3
-torlock: 2.23
-torrentproject: 1.4
+solidtorrents: 2.4
+torlock: 2.24
+torrentproject: 1.5
 torrentscsv: 1.4


### PR DESCRIPTION
In many plugins the HTML parser's state isn't reset between pages. It is initialized once and then feed() is called multiple times. 

This means that if a page ends in a weird state (eg in the middle of a row because truncated or temporary error or unexpected html), all following pages would fail to find results.

torrentproject noticed the issue and overrode feed() to reset some of its state between pages.

This PR changes the logic to create a new parser for each page. There is no reason not to (creating a parser isn't slow or anything). 

Multi-page support was also updated to keep searching until less/no results are found in a page (up to 5). This is in contrast to previously where a plugin would check the page size (unreliable) or extract page links (unreliable because sometimes they truncate the links list like `[1] [2] ... [9] [10]`)
