### PR TITLE
Add plugin to find your IP

### DIFF
--- a/nova3/engines/whats_my_ip.py
+++ b/nova3/engines/whats_my_ip.py
@@ -1,0 +1,76 @@
+#VERSION: 1.00
+# AUTHORS: Qwerty <qwerty@qwerty.xyz>
+# This plugin is useful when you are configuring a VPN and need to verify that it works!
+
+from html.parser import HTMLParser
+from helpers import retrieve_url
+from novaprinter import prettyPrinter
+
+class whats_my_ip(object):
+
+	url = 'https://qwerty.xyz/'
+	name = "What's my IP?"
+	supported_categories = {'all': '0'}
+
+	service_url = 'http://ipip.cz/'
+
+	def search(self, what, cat='all'):
+		response = retrieve_url(self.service_url)
+
+		parser = IPParser()
+		parser.feed(response)
+
+		prettyPrinter({
+			'link': self.service_url,
+			'name': f"IP Address: {parser.ip_address}",
+      # Says "Unknown" and can be sorted to the top by smallest size
+			'size': -1,
+			# Sort the result to the top by Seeds
+			'seeds': 1000001,
+			'leech': 1337,
+			'engine_url': self.service_url,
+			'desc_link': self.service_url,
+			'pub_date': -1
+		})
+
+		prettyPrinter({
+			'link': self.service_url,
+			'name': f"Hostname: {parser.hostname}",
+      # Says "Unknown" and can be sorted to the top by smallest size
+			'size': -1,
+			# Sort the result to the top by Seeds
+			'seeds': 1000000,
+			'leech': 1337,
+			'engine_url': self.service_url,
+			'desc_link': self.service_url,
+			'pub_date': -1
+		})
+
+class IPParser(HTMLParser):
+	def __init__(self):
+		super().__init__()
+		self.in_ip_div = False
+		self.ip_address = ""
+		self.hostname = ""
+		self.data_buffer = []
+
+	def handle_starttag(self, tag, attrs):
+		if tag == 'div':
+			for attr in attrs:
+				if attr[0] == 'class' and attr[1] == 'ip':
+					self.in_ip_div = True
+
+	def handle_endtag(self, tag):
+		if tag == 'div' and self.in_ip_div:
+			self.in_ip_div = False
+			data_str = ''.join(self.data_buffer)
+			self.data_buffer = []
+			if 'Moje IP adresa:' in data_str:
+				parts = data_str.split('Moje IP adresa:')
+				ip_part = parts[1].split('Hostname:')
+				self.ip_address = ip_part[0].strip()
+				self.hostname = ip_part[1].strip()
+
+	def handle_data(self, data):
+		if self.in_ip_div:
+			self.data_buffer.append(data)


### PR DESCRIPTION
Hello frens, I recently installed qBittorrent in a docker under Synology NAS and needed a way to confirm that my VPN configuration (made also in docker) actually works. I couldn't find a way to natively display such information in qBittorrent, there is no browser window too, so I wrote a simple search plugin and "hijacked" it to perform the request for me.

I hope you like it and that it gets included in qBittorrent, and maybe, in the future, even as a native feature available from the menu, but in the meantime, this is a good enough way to go.

If for any reason you don't think it is a great idea, feel free to ignore it as I already accomplished my goal. However, I believe it can be a handy tool for those who need to ensure their VPN is working correctly with qBittorrent, hence why I am making the effort to share it.

Cheers! 🥂 :shipit: 

---

This is how it looks
![image](https://github.com/user-attachments/assets/992cce22-7808-41b3-a52d-9aa4cceb5ecd)

---

PS: I later found out that it is possible to learn the IP from the View > Log -> Execution Log -> filter:"Detected external IP", but this is not too comfortable for me. With the "workaround" above, I can verify my IP every time I search new torrents. The best solution would obviously probably be if the IP was right on the status bar, but that's a major change out of the scope of this simple plugin.