### PR TITLE
Add notes about new symbol used in Unofficial-search-plugins.mediawiki

### DIFF
--- a/wiki/Unofficial-search-plugins.mediawiki
+++ b/wiki/Unofficial-search-plugins.mediawiki
@@ -7,7 +7,7 @@ Here you can find unofficial search engine plugins for qBittorrent that are made
 * To write your own search plugins, please follow [[How-to-write-a-search-plugin|this tutorial]].
 * If you wrote one, you're welcome to add it to these tables. Please keep the list sorted by <code>Search Engine</code> name.
 * '''If you experience issues with any of the plugins posted here, please report to the author directly.''' In case the author is unresponsive, you can try to fix it yourself. Then you can edit this wiki page and update the link to your fixed plugin.
-* The plugins shown as ✖ or ❗ will result in the slowdown and malfunction of other plugins as well, hence the use of these plugins is strongly discouraged.
+* The plugins shown as ✖, ❗, or ❌ will result in the slowdown and malfunction of other plugins as well, hence the use of these plugins is strongly discouraged.
 
 ⚠️ We removed support for Python 2. Please upgrade to Python 3 to continue using the search function.
 The minimum supported Python version (across all platforms) is specified at [https://github.com/qbittorrent/qBittorrent/blob/master/INSTALL#L21-L23 here].


### PR DESCRIPTION
Tokyo Toshokan used new symbol ❌ to show it breaks qbt plugin system as shown in [here](https://github.com/qbittorrent/search-plugins/blob/6234ad9838f89f7edfe92fe5e9220f348f7911ff/wiki/Unofficial-search-plugins.mediawiki?plain=1#L406). However, it is not documented in the "Read First" section.