### PR TITLE
Fix response handling

### DIFF
--- a/nova3/engines/piratebay.py
+++ b/nova3/engines/piratebay.py
@@ -129,7 +129,7 @@ class piratebay(object):
             pass
 
         dataStr = data.decode(charset, 'replace')
-        dataStr = dataStr.replace('&quot;', '\\"')
+        dataStr = dataStr.replace('&quot;', '\\"')  # Manually escape &quot; before
         dataStr = html.unescape(dataStr)
 
         return dataStr

--- a/nova3/engines/piratebay.py
+++ b/nova3/engines/piratebay.py
@@ -28,12 +28,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import json
-from urllib.parse import urlencode, unquote
-import urllib.request
-import io
 import gzip
 import html
+import io
+import json
+import urllib.error
+import urllib.request
+from urllib.parse import urlencode, unquote
 
 from novaprinter import prettyPrinter
 from helpers import getBrowserUserAgent
@@ -75,11 +76,8 @@ class piratebay(object):
         if category != '0':
             params['cat'] = category
 
-        url = base_url % urlencode(params)
-
-        data = self.retrieve_url(url)
-
-        # response = retrieve_url(base_url % urlencode(params))
+        # Calling custom `retrieve_url` function with adequate escaping
+        data = self.retrieve_url(base_url % urlencode(params))
         response_json = json.loads(data)
 
         # check empty response
@@ -112,14 +110,14 @@ class piratebay(object):
 
         try:
             response = urllib.request.urlopen(request)
-        except:
+        except urllib.error.HTTPError:
             return ""
 
         data: bytes = response.read()
 
         if data[:2] == b'\x1f\x8b':
             # Data is gzip encoded, decode it
-            with io.BytesIO(data) as compressedStream, gzip.GzipFile(fileobj=compressedStream) as gzipper:
+            with io.BytesIO(data) as stream, gzip.GzipFile(fileobj=stream) as gzipper:
                 data = gzipper.read()
 
         charset = 'utf-8'

--- a/nova3/engines/piratebay.py
+++ b/nova3/engines/piratebay.py
@@ -36,8 +36,8 @@ import urllib.error
 import urllib.request
 from urllib.parse import urlencode, unquote
 
-from novaprinter import prettyPrinter
 from helpers import getBrowserUserAgent
+from novaprinter import prettyPrinter
 
 
 class piratebay(object):
@@ -113,7 +113,7 @@ class piratebay(object):
         except urllib.error.HTTPError:
             return ""
 
-        data: bytes = response.read()
+        data = response.read()
 
         if data[:2] == b'\x1f\x8b':
             # Data is gzip encoded, decode it

--- a/nova3/engines/versions.txt
+++ b/nova3/engines/versions.txt
@@ -1,7 +1,7 @@
 eztv: 1.16
 jackett: 4.0
 limetorrents: 4.10
-piratebay: 3.3
+piratebay: 3.4
 solidtorrents: 2.4
 torlock: 2.24
 torrentproject: 1.5


### PR DESCRIPTION
## Following
- [this issue](https://github.com/qbittorrent/qBittorrent/issues/22074) on the main qBittorrent repository
- and the discussion on [this subsequent pull request](https://github.com/qbittorrent/qBittorrent/pull/22075) 

Here is the fix for the piratebay search engine. A gist of the code is available [here](https://gist.github.com/biskweet/f06ff7b260ef1ce3a31d27ac1a9edcbf) for testing.

## Recalling the problem:
API apibay.org returns weird JSON that causes the piratebay search engine to crash when handling its response. If some search results contain `"` (quotation marks) characters, the server escapes them by replacing `"` with `&quot;` HTML entities in order to still provide a syntactically valid JSON response. While this is not incorrect, it would be best if apibay.org returned properly escaped quotes, i.e. using backslashes.

When handling the response data, functions [`retrieve_url`](https://github.com/LightDestory/qBittorrent-Search-Plugins/blob/master/src/helpers.py#L75-L117) and [`htmlentitydecode`](https://github.com/LightDestory/qBittorrent-Search-Plugins/blob/master/src/helpers.py#L75-L117) blindly unescape all entities thereby corrupting previously valid JSON. As a consequence, `json.loads` crashes. For example:
```json
{
  "title": "Ubuntu 22.04.5 LTS (&quot;Jammy Jellyfish&quot;)"
}
```
becomes
```json
{
  "title": "Ubuntu 22.04.5 LTS ("Jammy Jellyfish")"
}
```

## Solution proposed
We no logner use the `retrieve_url` function -- instead, I created a dedicated `retrieve_url` function (which is almost a copy-paste of the orignal) that fixes the problem by manually escaping quotes *before* escaping the rest of the data.