### PR TITLE
Updated torlock URL

### DIFF
--- a/nova3/engines/torlock.py
+++ b/nova3/engines/torlock.py
@@ -1,4 +1,4 @@
-# VERSION: 2.24
+# VERSION: 2.25
 # AUTHORS: Douman (custparasite@gmx.se)
 # CONTRIBUTORS: Diego de las Heras (ngosang@hotmail.es)
 
@@ -10,7 +10,7 @@ from helpers import retrieve_url, download_file
 
 
 class torlock(object):
-    url = "https://www.torlock2.com"
+    url = "https://www.torlock.com"
     name = "TorLock"
     supported_categories = {'all': 'all',
                             'anime': 'anime',

--- a/nova3/engines/versions.txt
+++ b/nova3/engines/versions.txt
@@ -3,6 +3,6 @@ jackett: 4.0
 limetorrents: 4.10
 piratebay: 3.4
 solidtorrents: 2.4
-torlock: 2.24
+torlock: 2.25
 torrentproject: 1.5
 torrentscsv: 1.4


### PR DESCRIPTION
https://www.torlock2.com/ > 400 Bad Request No required SSL certificate was sent nginx

https://www.torlock.com/ -> is online