### PR TITLE
Adjust torrentscsv query size limit

### DIFF
--- a/nova3/engines/torrentscsv.py
+++ b/nova3/engines/torrentscsv.py
@@ -1,4 +1,4 @@
-# VERSION: 1.4
+# VERSION: 1.5
 # AUTHORS: Dessalines
 
 # Redistribution and use in source and binary forms, with or without
@@ -53,7 +53,7 @@ class torrentscsv(object):
     trackers = '&'.join(urlencode({'tr': tracker}) for tracker in trackers_list)
 
     def search(self, what, cat='all'):
-        search_url = "{}/service/search?size=300&q={}".format(self.url, what)
+        search_url = "{}/service/search?size=100&q={}".format(self.url, what)
         desc_url = "{}/#/search/torrent/{}/1".format(self.url, what)
 
         # get response json

--- a/nova3/engines/versions.txt
+++ b/nova3/engines/versions.txt
@@ -5,4 +5,4 @@ piratebay: 3.4
 solidtorrents: 2.4
 torlock: 2.25
 torrentproject: 1.5
-torrentscsv: 1.4
+torrentscsv: 1.5


### PR DESCRIPTION
Adjusted torrentscsv query size limit to be in-sync with upstream MAX_SIZE limit of `100`

https://git.torrents-csv.com/heretic/torrents-csv-server/commit/95c1d79282ea82b549232b94f0a88efd5dac091c

Prior to this change, torrentscsv would return no results & would display below error:
(when searching with all plugins/only enable plugins)

![Screenshot 2025-01-24 175145](https://github.com/user-attachments/assets/a654f0a7-da1d-4287-baf7-7e735d19ac67)

Found as part of investigations in https://github.com/qbittorrent/qBittorrent/pull/22163