### PR TITLE
Ignore qbt proxy settings when connecting to Jackett server

### DIFF
--- a/nova3/engines/versions.txt
+++ b/nova3/engines/versions.txt
@@ -1,5 +1,5 @@
 eztv: 1.16
-jackett: 4.1
+jackett: 4.2
 limetorrents: 4.10
 piratebay: 3.5
 solidtorrents: 2.4


### PR DESCRIPTION
The proxy is still used for other connections.