### PR TITLE
Added Sharewood plugin

### DIFF
--- a/wiki/Unofficial-search-plugins.mediawiki
+++ b/wiki/Unofficial-search-plugins.mediawiki
@@ -627,7 +627,7 @@ The minimum supported Python version (across all platforms) is specified at [htt
 | ✔ qbt 4.3.x / python 3.+
 |-
 | [[https://www.google.com/s2/favicons?domain=sharewood.tv#.png]] [https://sharewood.tv Sharewood]
-| [https://github.com/miIiano/SpeedApp.io-qBittorent-search-plugin miIiano]
+| [https://gist.github.com/etn406/2300dd7e8d97ea39442fcdf44c244fe2 etn]
 | 1.0
 | 24/Apr<br />2025
 | [https://gist.githubusercontent.com/etn406/2300dd7e8d97ea39442fcdf44c244fe2/raw/21f1fb783da4ea516b44091fda1fd749d8f5eef3/sharewood.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]

--- a/wiki/Unofficial-search-plugins.mediawiki
+++ b/wiki/Unofficial-search-plugins.mediawiki
@@ -626,6 +626,13 @@ The minimum supported Python version (across all platforms) is specified at [htt
 | [https://raw.githubusercontent.com/swannie-eire/prowlarr-qbittorrent-plugins/main/prowlarr.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]<br />[https://github.com/swannie-eire/prowlarr-qbittorrent-plugins [[https://github.com/Pireo/hello-world/blob/master/Help%20book.gif]] ]
 | ✔ qbt 4.3.x / python 3.+
 |-
+| [[https://www.google.com/s2/favicons?domain=sharewood.tv#.png]] [https://sharewood.tv Sharewood]
+| [https://github.com/miIiano/SpeedApp.io-qBittorent-search-plugin miIiano]
+| 1.0
+| 24/Apr<br />2025
+| [https://gist.githubusercontent.com/etn406/2300dd7e8d97ea39442fcdf44c244fe2/raw/21f1fb783da4ea516b44091fda1fd749d8f5eef3/sharewood.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]
+| ✔ qbt 5.0.3 / python 3.+
+|-
 | [[https://www.google.com/s2/favicons?domain=speedapp.io#.png]] [https://speedapp.io SpeedApp.IO]
 | [https://github.com/miIiano/SpeedApp.io-qBittorent-search-plugin miIiano]
 | 1.1

--- a/wiki/Unofficial-search-plugins.mediawiki
+++ b/wiki/Unofficial-search-plugins.mediawiki
@@ -628,9 +628,9 @@ The minimum supported Python version (across all platforms) is specified at [htt
 |-
 | [[https://www.google.com/s2/favicons?domain=sharewood.tv#.png]] [https://sharewood.tv Sharewood]
 | [https://gist.github.com/etn406/2300dd7e8d97ea39442fcdf44c244fe2 etn]
-| 1.0
+| 1.1
 | 24/Apr<br />2025
-| [https://gist.githubusercontent.com/etn406/2300dd7e8d97ea39442fcdf44c244fe2/raw/21f1fb783da4ea516b44091fda1fd749d8f5eef3/sharewood.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]
+| [https://gist.githubusercontent.com/etn406/2300dd7e8d97ea39442fcdf44c244fe2/raw/48eba68c0e32f9321ef2e47f4f8ecb437b093a61/sharewood.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]
 | ✔ qbt 5.0.3 / python 3.+
 |-
 | [[https://www.google.com/s2/favicons?domain=speedapp.io#.png]] [https://speedapp.io SpeedApp.IO]


### PR DESCRIPTION
Added a plugin for the private tracker Sharewood, it requires the user's passkey. Search can be filtered by category. There's no way to request ordering/pagination with Sharewood's API, so it just retrieves the 100 first results by default in an unknown order.

I tried it on my qBittorrent v5.0.5 (web UI) docker container successfully, tell me if more tests are needed.

Here's the script https://gist.github.com/etn406/2300dd7e8d97ea39442fcdf44c244fe2