### PR TITLE
docs: move link to unofficial yts.mx plugin to codeberg.org

### DIFF
--- a/wiki/Unofficial-search-plugins.mediawiki
+++ b/wiki/Unofficial-search-plugins.mediawiki
@@ -491,10 +491,10 @@ The minimum supported Python version (across all platforms) is specified at [htt
 | ✔ qbt 4.3.x / python 3.8.5
 |-
 | [[https://github.com/Pireo/hello-world/blob/master/yts.png]] [http://yts.mx/ YTS.MX]
-| [https://github.com/lazulyra/qbit-plugins lazulyra]
+| [https://codeberg.org/lazulyra/qbit-plugins lazulyra]
 | 1.2
 | 07/Jan<br />2024
-| [https://raw.githubusercontent.com/lazulyra/qbit-plugins/main/yts_mx/yts_mx.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]]]
+| [https://codeberg.org/lazulyra/qbit-plugins/raw/branch/main/yts_mx/yts_mx.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]]]
 | ✔ qbt 4.6.2 / python 3.12.0
 |-
 | 🔍


### PR DESCRIPTION
I'm moving my code over to Codeberg, and the repository on GitHub will be deleted in the next few days.