### PR TITLE
fix(unofficial-plugins): change YTS URL to domainless repository path

### DIFF
--- a/wiki/Unofficial-search-plugins.mediawiki
+++ b/wiki/Unofficial-search-plugins.mediawiki
@@ -490,11 +490,11 @@ The minimum supported Python version (across all platforms) is specified at [htt
 | [https://raw.githubusercontent.com/LightDestory/qBittorrent-Search-Plugins/master/src/engines/yourbittorrent.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]
 | ✔ qbt 4.3.x / python 3.8.5
 |-
-| [[https://github.com/Pireo/hello-world/blob/master/yts.png]] [http://yts.mx/ YTS.MX]
+| [[https://github.com/Pireo/hello-world/blob/master/yts.png]] [http://yts.lt/ YTS]
 | [https://codeberg.org/lazulyra/qbit-plugins lazulyra]
-| 1.2
-| 07/Jan<br />2024
-| [https://codeberg.org/lazulyra/qbit-plugins/raw/branch/main/yts_mx/yts_mx.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]]]
+| 1.6
+| 25/Nov<br />2025
+| [https://codeberg.org/lazulyra/qbit-plugins/raw/branch/main/yts/yts.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]]]
 | ✔ qbt 4.6.2 / python 3.12.0
 |-
 | 🔍


### PR DESCRIPTION
To reflect changes in upstream repository, to account for domain change from .mx to .lt (and prevent further domain changes causing a similar issue).