### PR TITLE
Change torrentproject URL

### DIFF
--- a/nova3/engines/torrentproject.py
+++ b/nova3/engines/torrentproject.py
@@ -1,4 +1,4 @@
-# VERSION: 1.9
+# VERSION: 1.91
 # AUTHORS: mauricci
 
 import re
@@ -12,7 +12,7 @@ from novaprinter import prettyPrinter
 
 
 class torrentproject:
-    url = 'https://torrentproject.cc'
+    url = 'https://torrentproject.com.se'
     name = 'TorrentProject'
     supported_categories = {'all': '0'}
 

--- a/nova3/engines/versions.txt
+++ b/nova3/engines/versions.txt
@@ -4,5 +4,5 @@ limetorrents: 4.14
 piratebay: 3.9
 solidtorrents: 2.8
 torlock: 2.28
-torrentproject: 1.9
+torrentproject: 1.91
 torrentscsv: 1.8


### PR DESCRIPTION
The old site address (torrentproject.cc) no longer works.