### PR TITLE
Add SkTorrent plugin to the unofficial search plugins list

### DIFF
--- a/wiki/Unofficial-search-plugins.mediawiki
+++ b/wiki/Unofficial-search-plugins.mediawiki
@@ -335,6 +335,13 @@ The minimum supported Python version (across all platforms) is specified at [htt
 | [https://raw.githubusercontent.com/imDMG/qBt_SE/master/engines/rutor.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]<br /> [https://github.com/imDMG/qBt_SE/blob/master/README.md#rutrackerorg [[https://github.com/Pireo/hello-world/blob/master/Help%20book.gif]] ]
 | ✔ qbt 4.2.x / python 3.7+
 |-
+|[[https://www.google.com/s2/favicons?domain=sktorrent.eu#.png]] [https://sktorrent.eu SkTorrent]
+|[https://github.com/Ashalda/sktorrent-qbt Ashalda]
+|1.1
+|27/Dec<br />2025
+|[https://raw.githubusercontent.com/LightDestory/qBittorrent-Search-Plugins/master/src/engines/snowfl.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]
+|✔ qbt 5.1.x / python 3.9.x <br />WORKING WITHOUT LOGIN - EVERYTHING EXCEPT XXX AND SOFTWARE
+|-
 | [[https://raw.githubusercontent.com/hannsen/qbittorrent_search_plugins/master/smallgames.png]] [http://small-games.info/ small-games.info]
 | [https://github.com/hannsen/qbittorrent_search_plugins/ hannsen]
 | 1.00
@@ -348,13 +355,6 @@ The minimum supported Python version (across all platforms) is specified at [htt
 |28/Jul<br />2022
 |[https://raw.githubusercontent.com/LightDestory/qBittorrent-Search-Plugins/master/src/engines/snowfl.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]
 |✔ qbt 4.3.x / python 3.8.5 <br />**READ REPOSITORY NOTES**
-|-
-|[[https://www.google.com/s2/favicons?domain=sktorrent.eu#.png]] [https://sktorrent.eu SkTorrent]
-|[https://github.com/Ashalda/sktorrent-qbt Ashalda]
-|1.1
-|27/Dec<br />2025
-|[https://raw.githubusercontent.com/LightDestory/qBittorrent-Search-Plugins/master/src/engines/snowfl.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]
-|✔ qbt 5.1.x / python 3.9.x <br />WORKING WITHOUT LOGIN - EVERYTHING EXCEPT XXX AND SOFTWARE
 |-
 | [[https://www.google.com/s2/favicons?domain=solidtorrents.to#.png]] [https://solidtorrents.to/ SolidTorrents.to]
 | [https://github.com/BurningMop/qBittorrent-Search-Plugins BurningMop]


### PR DESCRIPTION
Hello, I would like to add my SkTorrent plugin to the unofficial search plugins. It works without account, but doesnt show 2 categories: XXX and software. But I think thats okay. Movies and TV shows are working flawless.

Site: sktorrent.eu
Author: Ashalda
Version: 1.1
Last update: 27/Dec/2025
Link:   https://raw.githubusercontent.com/Ashalda/sktorrent-qbt/refs/heads/main/sktorrent.py
Info: WORKING WITHOUT LOGIN, NO XXX