### PR TITLE
Add new plugins: nekoBT, UIndex, Lat-Team, gog-games, milkie + fix and update UnionFansub plugin

### DIFF
--- a/wiki/Unofficial-search-plugins.mediawiki
+++ b/wiki/Unofficial-search-plugins.mediawiki
@@ -258,6 +258,13 @@ The minimum supported Python version (across all platforms) is specified at [htt
 | [https://raw.githubusercontent.com/BurningMop/qBittorrent-Search-Plugins/refs/heads/main/naranjatorrent.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]
 | ✔ qbt 5.0.x / python 3.9.x
 |-
+| [[https://raw.githubusercontent.com/tolotp/qbittorrent-search-plugins-de-busqueda/refs/heads/main/Images/nekobt.png]] [https://nekobt.to/ nekoBT]
+| [https://github.com/tolotp/qbittorrent-search-plugins-de-busqueda tolotp]
+| 1.0
+| 06/Mar/2026
+| [https://raw.githubusercontent.com/tolotp/qbittorrent-search-plugins-de-busqueda/refs/heads/main/Plugins/nekobt.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]
+| ✔ qbt 4.5.x+ / python 3.9.x+
+|-
 | [[https://raw.githubusercontent.com/4chenz/pantsu-plugin/master/pantsu.png]] [https://nyaa.pantsu.cat/ Nyaa.Pantsu]
 | [https://github.com/4chenz/pantsu-plugin/ 4chenz]
 | 1.21
@@ -462,6 +469,13 @@ The minimum supported Python version (across all platforms) is specified at [htt
 | [https://raw.githubusercontent.com/BurningMop/qBittorrent-Search-Plugins/refs/heads/main/traht.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]
 | ✔ qbt 4.6.x / python 3.9.x
 |-
+| [[https://www.google.com/s2/favicons?domain=uindex.org#.png]] [https://uindex.org/ UIndex}
+| [https://github.com/tolotp/qbittorrent-search-plugins-de-busqueda tolotp]
+| 1.0
+| 05/Mar/2026
+| [https://raw.githubusercontent.com/tolotp/qbittorrent-search-plugins-de-busqueda/refs/heads/main/Plugins/uindex.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]
+| ✔️ qbt 4.5.x+ / python 3.9.x+
+|-
 | [[https://github.com/msagca/qbittorrent-plugins/blob/main/uniondht_icon.png]] [http://uniondht.org/ UnionDHT]
 | [https://github.com/msagca/qbittorrent-plugins/ msagca]
 | 1.2
@@ -563,6 +577,13 @@ The minimum supported Python version (across all platforms) is specified at [htt
 | [https://raw.githubusercontent.com/imDMG/qBt_SE/master/engines/kinozal.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]<br /> [https://github.com/imDMG/qBt_SE/blob/master/README.md [[https://github.com/Pireo/hello-world/blob/master/Help%20book.gif]] ]
 | ✔ qbt 4.2.x / python 3.7+
 |-
+| [[https://www.google.com/s2/favicons?domain=lat-team.com#.png]] [https://lat-team.com Lat-Team]
+| [https://github.com/tolotp/qbittorrent-search-plugins-de-busqueda tolotp]
+| 1.0
+| 06/Mar/2026
+| [https://raw.githubusercontent.com/tolotp/qbittorrent-search-plugins-de-busqueda/refs/heads/main/Plugins/latteam.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]<br /> [https://github.com/tolotp/qbittorrent-search-plugins-de-busqueda/wiki/Gu%C3%ADa-para-plugin-Lat%E2%80%90team [[https://github.com/Pireo/hello-world/blob/master/Help%20book.gif]] ]
+| ✔️ qbt 4.5.x+ / python 3.9.x+<br />  ❗ Pls read the guide
+|-
 | [[https://github.com/bugsbringer/qbit-plugins/blob/master/lostfilm.png]] [https://www.lostfilm.tv/ LostFilm.TV]
 | [https://github.com/bugsbringer/qbit-plugins Bugsbringer]
 | 0.14
@@ -653,6 +674,13 @@ The minimum supported Python version (across all platforms) is specified at [htt
 | 19/Dec<br />2025
 | [https://raw.githubusercontent.com/playday3008/qBittorrent-plugins/refs/heads/main/plugins/search/toloka_to.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]]]
 | ✔ qbt 5.1.x / python 3.11+
+|-
+| [[https://www.google.com/s2/favicons?domain=unionfansub.com#.png]] [https://torrent.unionfansub.com/ UnionFansub]
+| [https://github.com/tolotp/qbittorrent-search-plugins-de-busqueda tolotp]
+| 2.0
+| 05/Mar/2026
+| [https://raw.githubusercontent.com/tolotp/qbittorrent-search-plugins-de-busqueda/refs/heads/main/Plugins/unionfansub.py  [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]]]<br /> [https://github.com/tolotp/qbittorrent-search-plugins-de-busqueda/wiki/Gu%C3%ADa-para-plugin-Uni%C3%B3n-fansub [[https://github.com/Pireo/hello-world/blob/master/Help%20book.gif]] ]
+| ✔️ qbt 4.5.x+ / python 3.9.x+<br />  ❗ Pls read the guide
 |-
 | [[https://www.google.com/s2/favicons?domain=unionfansub.com#.png]] [https://torrent.unionfansub.com/ UnionFansub]
 | [https://gitlab.com/CrimsonKoba/qb-search-plugin CrimsonKoba]

--- a/wiki/Unofficial-search-plugins.mediawiki
+++ b/wiki/Unofficial-search-plugins.mediawiki
@@ -187,6 +187,13 @@ The minimum supported Python version (across all platforms) is specified at [htt
 | [https://raw.githubusercontent.com/LightDestory/qBittorrent-Search-Plugins/master/src/engines/glotorrents.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]
 | ✔ qbt 4.3.5 / python 3.8.5
 |-
+| [[https://gog-games.to/favicon-16x16.png]] [https://gog-games.to/ Gog-games]
+| [https://github.com/tolotp/qbittorrent-search-plugins-de-busqueda tolotp]
+| 1.0
+| 10/Mar/2026
+| [https://raw.githubusercontent.com/tolotp/qbittorrent-search-plugins-de-busqueda/refs/heads/main/Plugins/goggames.py] [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]
+| ✔️ qbt 4.5.x+ / python 3.9.x+<br />  ❗ Pls read this [https://github.com/tolotp/qbittorrent-search-plugins-de-busqueda/wiki/Plugin-gog%E2%80%90games-(ESPA%C3%91OL-%7C-ENGLISH) INFO]
+|-
 | [[https://github.com/LightDestory/qBittorrent-Search-Plugins/raw/master/src/engines/kickasstorrents.png]] [https://katcr.to/  Kickass Torrent]
 | [https://github.com/LightDestory/qBittorrent-Search-Plugins LightDestory]
 | 1.0
@@ -590,6 +597,13 @@ The minimum supported Python version (across all platforms) is specified at [htt
 | 13/Jun<br />2020
 | [https://raw.githubusercontent.com/bugsbringer/qbit-plugins/master/lostfilm.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]<br /> [https://github.com/bugsbringer/qbit-plugins/blob/master/README.md [[https://github.com/Pireo/hello-world/blob/master/Help%20book.gif]] ]
 | ✔ qbt 4.2.x / python 3.5.0
+|-
+| [[https://www.google.com/s2/favicons?domain=milkie.cc]] [https://milkie.cc Milkie]
+| [https://github.com/tolotp/qbittorrent-search-plugins-de-busqueda tolotp]
+| 1.0
+| 10/Mar/2026 
+| [https://raw.githubusercontent.com/tolotp/qbittorrent-search-plugins-de-busqueda/refs/heads/main/Plugins/milkie.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]] ]<br /> [https://github.com/tolotp/qbittorrent-search-plugins-de-busqueda/wiki/Guia-plugin-Milkie [[https://github.com/Pireo/hello-world/blob/master/Help%20book.gif]] ]
+| ✔️ qbt 4.5.x+ / python 3.9.x+<br />  ❗ Pls read the guide
 |-
 | [[https://raw.githubusercontent.com/darktohka/qbittorrent-plugins/master/resources/ncore.png]] [https://ncore.pro/ nCore]
 | [https://github.com/darktohka/qbittorrent-plugins darktohka]


### PR DESCRIPTION
This PR adds new plugins for the following sites/trackers: nekoBT, Lat-Team, UIndex, gog-games and milkie. It also fixes and updates the UnionFansub plugin and includes a configuration guide. Lat-Team is a private tracker specialized in Spanish content (I added a configuration guide for it as well).

If you want to try the plugins and give me some feedback, you can do so here:
https://github.com/tolotp/qbittorrent-search-plugins-de-busqueda/blob/main/README-ENG.md

_Note: I know some of these plugins are already on Jackett, but I still wanted to make a version for qBittorrent._
> I wrote the guides in Spanish for Lat-Team and UnionFansub because those sites focus on Spanish content. You can use a translator if needed.