### PR TITLE
Add Zamunda.RIP search plugin (supersedes #415 — fixes broken raw URL)

### DIFF
--- a/wiki/Unofficial-search-plugins.mediawiki
+++ b/wiki/Unofficial-search-plugins.mediawiki
@@ -740,4 +740,11 @@ The minimum supported Python version (across all platforms) is specified at [htt
 | 25/Nov<br>2019
 | [https://raw.githubusercontent.com/CravateRouge/qBittorrentSearchPlugins/master/yggtorrent.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]]]<br> [https://github.com/CravateRouge/qBittorrentSearchPlugins/blob/master/README.md [[https://github.com/Pireo/hello-world/blob/master/Help%20book.gif]]]
 | ❗ Working when DDOS cloudfare<br>protection is disabled
+|-
+| [[https://www.google.com/s2/favicons?domain=zamunda.rip#.png]] [https://zamunda.rip/ Zamunda.RIP]
+| [https://github.com/codeobfuscation/qBittorrent-ZamundaRIP-plugin Necrosis]
+| 1.0
+| 22/May<br>2026
+| [https://raw.githubusercontent.com/codeobfuscation/qBittorrent-ZamundaRIP-plugin/main/zamundarip.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]]]
+| ✔ qbt 5.1.x / Python 3.9+
 |}


### PR DESCRIPTION
Adds Zamunda.RIP to the unofficial search plugins list.

**Plugin repository:** https://github.com/codeobfuscation/qBittorrent-ZamundaRIP-plugin
**Plugin file (raw):** https://raw.githubusercontent.com/codeobfuscation/qBittorrent-ZamundaRIP-plugin/main/zamundarip.py
**Compatibility:** qBittorrent 5.1.x / Python 3.9+

### About
Zamunda.RIP is a self-hosted archive of three defunct Bulgarian torrent sites (Zamunda.net, ArenaBG, Zelka.org) — ~450 000 magnets, fully indexed with SQLite FTS5. The plugin queries the public Torznab endpoint exposed at https://zamunda.rip/api/torznab/api so it works out-of-the-box with no auth.

### Supersedes #415
The previous attempt (#415) had a broken raw URL — it pointed to `main/engines/zamundarip.py`, but the file actually lives at the repo root (`main/zamundarip.py`). That's now corrected in this PR. I also switched the icon to the same `?domain=zamunda.rip` favicon-proxy pattern several other plugins on this list use, so it's a permanent self-resolving link rather than a third-party imgur upload.