### PR TITLE
Add TorrentHunter metasearch plugin

### DIFF
--- a/nova3/engines/torrenthunter.py
+++ b/nova3/engines/torrenthunter.py
@@ -3,9 +3,16 @@
 # LICENSE: MIT
 """Fast, configurable metasearch plugin for qBittorrent.
 
-This file is intentionally self-contained because qBittorrent installs search
-plugins one Python file at a time. Configuration is read from
-``torrenthunter.json`` next to this file.
+The plugin works immediately after installing this file and uses its embedded
+defaults, which enable the public Torrents.csv source. No JSON file is included
+or required.
+
+Optional settings and additional sources such as Prowlarr and Jackett can be
+configured by creating ``torrenthunter.json`` beside the installed
+``torrenthunter.py`` file. The JSON values override the embedded defaults; in
+particular, copy the relevant source entry from ``DEFAULT_CONFIG`` below and
+replace ``YOUR_API_KEY_HERE`` with the API key for your own local service.
+Never publish a configuration containing a real API key.
 """
 
 from __future__ import annotations

--- a/nova3/engines/torrenthunter.py
+++ b/nova3/engines/torrenthunter.py
@@ -11,6 +11,7 @@ plugins one Python file at a time. Configuration is read from
 from __future__ import annotations
 
 import datetime
+import difflib
 import email.utils
 import hashlib
 import json
@@ -51,7 +52,12 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "circuit_breaker_seconds": 300,
     "minimum_seeders": 0,
     "maximum_age_days": 0,
-    "ranking": {"relevance": 1000, "seeders": 10, "freshness": 1},
+    "ranking": {
+        "relevance": 1000,
+        "fuzzy_similarity": 500,
+        "seeders": 10,
+        "freshness": 1,
+    },
     "adaptive_search": {
         "enabled": True,
         "target_unique_results": 75,
@@ -250,6 +256,21 @@ TECHNICAL_QUERY_TOKENS = re.compile(
     r")$",
     re.IGNORECASE,
 )
+TITLE_STOP_WORDS = {
+    "a",
+    "an",
+    "and",
+    "of",
+    "the",
+}
+
+
+def _meaningful_tokens(text: str) -> List[str]:
+    return [
+        token
+        for token in _normal_name(text).split()
+        if token not in TITLE_STOP_WORDS and not TECHNICAL_QUERY_TOKENS.match(token)
+    ]
 
 
 def _query_variants(query: str) -> List[str]:
@@ -263,6 +284,16 @@ def _query_variants(query: str) -> List[str]:
         variants.append(normalized)
 
     tokens = normalized.split()
+    without_stop_words = " ".join(
+        token for token in tokens if token.casefold() not in TITLE_STOP_WORDS
+    )
+    if (
+        len(without_stop_words.split()) >= 1
+        and without_stop_words.casefold()
+        not in {item.casefold() for item in variants}
+    ):
+        variants.append(without_stop_words)
+
     relaxed_tokens = [token for token in tokens if not TECHNICAL_QUERY_TOKENS.match(token)]
     relaxed = " ".join(relaxed_tokens)
     if (
@@ -292,6 +323,66 @@ def _query_variants(query: str) -> List[str]:
     return variants
 
 
+def _fuzzy_title_similarity(name: str, query: str) -> float:
+    query_tokens = _meaningful_tokens(urllib.parse.unquote_plus(query))
+    name_tokens = _meaningful_tokens(name)
+    if not query_tokens or not name_tokens:
+        return 0.0
+    window_size = len(query_tokens)
+    candidate_windows = [
+        name_tokens[start: start + window_size]
+        for start in range(max(1, len(name_tokens) - window_size + 1))
+    ]
+    phrase = " ".join(query_tokens)
+    return max(
+        difflib.SequenceMatcher(None, phrase, " ".join(window)).ratio()
+        for window in candidate_windows
+    )
+
+
+def _fuzzy_correction(
+    query: str, results: Iterable[Mapping[str, Any]]
+) -> Optional[str]:
+    normalized = re.sub(
+        r"\s+", " ", re.sub(r"[._]+", " ", urllib.parse.unquote_plus(query))
+    ).strip()
+    query_tokens = normalized.split()
+    candidate_counts: Dict[str, int] = {}
+    for result in results:
+        for token in set(_meaningful_tokens(str(result.get("name", "")))):
+            candidate_counts[token] = candidate_counts.get(token, 0) + 1
+
+    replacements: Dict[str, str] = {}
+    for token in query_tokens:
+        folded = token.casefold()
+        if (
+            len(folded) < 5
+            or folded in TITLE_STOP_WORDS
+            or TECHNICAL_QUERY_TOKENS.match(folded)
+        ):
+            continue
+        candidates = [
+            candidate
+            for candidate, count in candidate_counts.items()
+            if count >= 2 and candidate != folded
+        ]
+        if not candidates:
+            continue
+        scored_candidates = [
+            (difflib.SequenceMatcher(None, folded, candidate).ratio(), candidate)
+            for candidate in candidates
+        ]
+        best = max(scored_candidates)[1]
+        if difflib.SequenceMatcher(None, folded, best).ratio() >= 0.82:
+            replacements[folded] = best.capitalize() if token[:1].isupper() else best
+    if not replacements:
+        return None
+    corrected = " ".join(
+        replacements.get(token.casefold(), token) for token in query_tokens
+    )
+    return corrected if corrected.casefold() != normalized.casefold() else None
+
+
 def _dedupe_key(result: Mapping[str, Any]) -> str:
     info_hash = _info_hash(str(result.get("link", "")))
     if info_hash:
@@ -315,6 +406,8 @@ def _score(result: Mapping[str, Any], query: str, config: Mapping[str, Any]) -> 
         freshness_days = max(0.0, (time.time() - published) / 86400)
     return (
         relevance * float(weights.get("relevance", 1000))
+        + _fuzzy_title_similarity(str(result.get("name", "")), query)
+        * float(weights.get("fuzzy_similarity", 500))
         + max(0, seeds) * float(weights.get("seeders", 10))
         - freshness_days * float(weights.get("freshness", 1))
     )
@@ -485,21 +578,38 @@ def _search_with_expansion(
     category: str,
     timeout: float,
 ) -> List[Dict[str, Any]]:
-    variants = _query_variants(query)
     adaptive = source.get("_adaptive", {})
     enabled = bool(adaptive.get("enabled", True))
     target = max(1, _integer(adaptive.get("target_unique_results"), 75))
     extras = max(0, _integer(adaptive.get("max_extra_queries"), 3))
-    selected = variants[: 1 + extras] if enabled else variants[:1]
     unique: Dict[str, Dict[str, Any]] = {}
-    for number, variant in enumerate(selected):
-        if number > 0 and len(unique) >= target:
-            break
+
+    def add_variant(variant: str) -> None:
         for result in adapter(source, variant, category, timeout):
             key = _dedupe_key(result)
             previous = unique.get(key)
             if previous is None or _quality(result, query) > _quality(previous, query):
                 unique[key] = result
+
+    add_variant(urllib.parse.unquote_plus(query).strip())
+    if not enabled or len(unique) >= target:
+        return list(unique.values())
+
+    candidates: List[str] = []
+    correction = _fuzzy_correction(query, unique.values())
+    if correction:
+        candidates.append(correction)
+    candidates.extend(_query_variants(query)[1:])
+    seen = {urllib.parse.unquote_plus(query).strip().casefold()}
+    extra_count = 0
+    for variant in candidates:
+        if extra_count >= extras or len(unique) >= target:
+            break
+        if not variant or variant.casefold() in seen:
+            continue
+        seen.add(variant.casefold())
+        add_variant(variant)
+        extra_count += 1
     return list(unique.values())
 
 

--- a/nova3/engines/torrenthunter.py
+++ b/nova3/engines/torrenthunter.py
@@ -1,0 +1,646 @@
+# VERSION: 0.20
+# AUTHORS: TorrentHunter contributors
+# LICENSE: MIT
+"""Fast, configurable metasearch plugin for qBittorrent.
+
+This file is intentionally self-contained because qBittorrent installs search
+plugins one Python file at a time. Configuration is read from
+``torrenthunter.json`` next to this file.
+"""
+
+from __future__ import annotations
+
+import datetime
+import email.utils
+import hashlib
+import json
+import os
+import re
+import sys
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, cast
+
+from helpers import download_file
+from novaprinter import SearchResults, prettyPrinter
+
+VERSION = "0.2.0"
+CONFIG_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "torrenthunter.json"
+)
+TORZNAB_NS = "http://torznab.com/schemas/2015/feed"
+USER_AGENT = f"TorrentHunter/{VERSION} qBittorrent-search-plugin"
+PRINT_LOCK = threading.Lock()
+STATE_PATH = os.path.join(os.path.dirname(CONFIG_PATH), "torrenthunter.state.json")
+
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "timeout_seconds": 12,
+    "max_workers": 8,
+    "max_results_per_source": 1000,
+    "show_source_in_name": True,
+    "retries": 2,
+    "retry_backoff_seconds": 0.4,
+    "cache_ttl_seconds": 300,
+    "stale_cache_on_error": True,
+    "failure_threshold": 3,
+    "circuit_breaker_seconds": 300,
+    "minimum_seeders": 0,
+    "maximum_age_days": 0,
+    "ranking": {"relevance": 1000, "seeders": 10, "freshness": 1},
+    "adaptive_search": {
+        "enabled": True,
+        "target_unique_results": 75,
+        "max_extra_queries": 3,
+    },
+    "sources": [
+        {
+            "name": "Torrents.csv",
+            "type": "torrentscsv",
+            "url": "https://torrents-csv.com",
+            "enabled": True,
+        },
+        {
+            "name": "Prowlarr",
+            "type": "prowlarr",
+            "url": "http://127.0.0.1:9696/api/v1/search",
+            "api_key": "YOUR_API_KEY_HERE",
+            "enabled": False,
+        },
+        {
+            "name": "Jackett",
+            "type": "torznab",
+            "url": (
+                "http://127.0.0.1:9117/api/v2.0/indexers/all/"
+                "results/torznab/api"
+            ),
+            "api_key": "YOUR_API_KEY_HERE",
+            "enabled": False,
+        },
+    ],
+}
+
+CATEGORIES = {
+    "all": (),
+    "anime": ("5070",),
+    "books": ("7000", "8000"),
+    "games": ("1000",),
+    "movies": ("2000",),
+    "music": ("3000",),
+    "pictures": ("6000",),
+    "software": ("4000",),
+    "tv": ("5000",),
+}
+
+
+def _stderr(message: str) -> None:
+    print(f"TorrentHunter: {message}", file=sys.stderr)
+
+
+def _load_config() -> Dict[str, Any]:
+    if not os.path.exists(CONFIG_PATH):
+        try:
+            with open(CONFIG_PATH, "w", encoding="utf-8") as config_file:
+                json.dump(DEFAULT_CONFIG, config_file, indent=2)
+        except OSError as exc:
+            _stderr(f"could not create configuration: {exc}")
+        return dict(DEFAULT_CONFIG)
+    try:
+        with open(CONFIG_PATH, encoding="utf-8") as config_file:
+            raw_loaded: Any = json.load(config_file)
+        if not isinstance(raw_loaded, dict):
+            raise ValueError("configuration must be an object")
+        loaded = cast(Dict[str, Any], raw_loaded)
+        if not isinstance(loaded.get("sources"), list):
+            raise ValueError("'sources' must be a list")
+        merged = dict(DEFAULT_CONFIG)
+        merged.update(loaded)
+        return merged
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        _stderr(f"invalid configuration, using defaults: {exc}")
+        return dict(DEFAULT_CONFIG)
+
+
+def _load_state() -> Dict[str, Any]:
+    try:
+        with open(STATE_PATH, encoding="utf-8") as state_file:
+            raw_state: Any = json.load(state_file)
+        if isinstance(raw_state, dict):
+            state = cast(Dict[str, Any], raw_state)
+            state.setdefault("sources", {})
+            state.setdefault("cache", {})
+            return state
+    except (OSError, ValueError, json.JSONDecodeError):
+        pass
+    return {"sources": {}, "cache": {}}
+
+
+def _save_state(state: Mapping[str, Any]) -> None:
+    temporary = STATE_PATH + ".tmp"
+    try:
+        with open(temporary, "w", encoding="utf-8") as state_file:
+            json.dump(state, state_file, separators=(",", ":"))
+        os.replace(temporary, STATE_PATH)
+    except OSError as exc:
+        _stderr(f"could not save state: {exc}")
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+
+
+def _source_id(source: Mapping[str, Any]) -> str:
+    identity = f"{source.get('type')}:{source.get('url')}:{source.get('name')}"
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:20]
+
+
+def _cache_key(source: Mapping[str, Any], query: str, category: str) -> str:
+    identity = f"{_source_id(source)}:{urllib.parse.unquote_plus(query).casefold()}:{category}"
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()
+
+
+def _request_text(
+    url: str,
+    timeout: float,
+    headers: Optional[Mapping[str, str]] = None,
+    retries: int = 0,
+    backoff: float = 0.0,
+) -> str:
+    request_headers = {
+        "User-Agent": USER_AGENT,
+        "Accept": "application/json, application/xml",
+    }
+    request_headers.update(headers or {})
+    request = urllib.request.Request(
+        url,
+        headers=request_headers,
+    )
+    for attempt in range(retries + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                data = cast(bytes, response.read())
+                return data.decode("utf-8", errors="replace")
+        except (OSError, urllib.error.URLError):
+            if attempt >= retries:
+                raise
+            time.sleep(backoff * (2 ** attempt))
+    raise RuntimeError("request retry loop ended unexpectedly")
+
+
+def _integer(value: Any, default: int = -1) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _timestamp(value: Optional[str]) -> int:
+    if not value:
+        return -1
+    try:
+        parsed = email.utils.parsedate_to_datetime(value)
+        return int(parsed.timestamp())
+    except (TypeError, ValueError, OverflowError):
+        try:
+            parsed_iso = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return int(parsed_iso.timestamp())
+        except (TypeError, ValueError, OverflowError):
+            return -1
+
+
+def _text(element: Optional[ET.Element], default: str = "") -> str:
+    return element.text.strip() if element is not None and element.text else default
+
+
+def _attr(item: ET.Element, name: str) -> Optional[str]:
+    element = item.find(f"./{{{TORZNAB_NS}}}attr[@name='{name}']")
+    return element.attrib.get("value") if element is not None else None
+
+
+def _append_query(url: str, values: Iterable[Tuple[str, str]]) -> str:
+    parsed = urllib.parse.urlsplit(url)
+    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    query.extend(values)
+    return urllib.parse.urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, urllib.parse.urlencode(query), parsed.fragment)
+    )
+
+
+def _info_hash(link: str) -> Optional[str]:
+    match = re.search(r"(?:urn:btih:|/)([A-Fa-f0-9]{40})(?:[&/?#]|$)", link)
+    return match.group(1).lower() if match else None
+
+
+def _normal_name(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", name.casefold()).strip()
+
+
+TECHNICAL_QUERY_TOKENS = re.compile(
+    r"^(?:"
+    r"\d{3,4}p|4k|"
+    r"x26[45]|h26[45]|hevc|av1|10bit|"
+    r"blu-?ray|b[dr]rip|web-?dl|webrip|hdtv|remux|"
+    r"hdr10?\+?|dolby|vision|dv|atmos|"
+    r"aac\d*|dts(?:-?hd)?|truehd|"
+    r"proper|repack|extended|unrated|multi|dubbed|subbed"
+    r")$",
+    re.IGNORECASE,
+)
+
+
+def _query_variants(query: str) -> List[str]:
+    exact = urllib.parse.unquote_plus(query).strip()
+    variants = [exact]
+
+    normalized = re.sub(r"[\[\]{}()\"']", " ", exact)
+    normalized = re.sub(r"[._]+", " ", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    if normalized and normalized.casefold() not in {item.casefold() for item in variants}:
+        variants.append(normalized)
+
+    tokens = normalized.split()
+    relaxed_tokens = [token for token in tokens if not TECHNICAL_QUERY_TOKENS.match(token)]
+    relaxed = " ".join(relaxed_tokens)
+    if (
+        len(relaxed_tokens) >= 2
+        and relaxed.casefold() not in {item.casefold() for item in variants}
+    ):
+        variants.append(relaxed)
+
+    tv_match = re.search(r"\bS(\d{1,2})E(\d{1,2})\b", normalized, re.IGNORECASE)
+    if tv_match:
+        alternate = re.sub(
+            r"\bS\d{1,2}E\d{1,2}\b",
+            f"{int(tv_match.group(1))}x{int(tv_match.group(2)):02d}",
+            normalized,
+            flags=re.IGNORECASE,
+        )
+        if alternate.casefold() not in {item.casefold() for item in variants}:
+            variants.append(alternate)
+
+    without_year = re.sub(r"\b(?:19|20)\d{2}\b", " ", relaxed or normalized)
+    without_year = re.sub(r"\s+", " ", without_year).strip()
+    if (
+        len(without_year.split()) >= 2
+        and without_year.casefold() not in {item.casefold() for item in variants}
+    ):
+        variants.append(without_year)
+    return variants
+
+
+def _dedupe_key(result: Mapping[str, Any]) -> str:
+    info_hash = _info_hash(str(result.get("link", "")))
+    if info_hash:
+        return f"hash:{info_hash}"
+    material = f"{_normal_name(str(result.get('name', '')))}:{result.get('size', -1)}"
+    return "fallback:" + hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _quality(result: Mapping[str, Any], query: str) -> Tuple[int, int, int]:
+    words = [word for word in re.split(r"\W+", urllib.parse.unquote_plus(query).casefold()) if word]
+    name = str(result.get("name", "")).casefold()
+    relevance = sum(1 for word in words if word in name)
+    return relevance, _integer(result.get("seeds")), _integer(result.get("pub_date"))
+
+
+def _score(result: Mapping[str, Any], query: str, config: Mapping[str, Any]) -> float:
+    relevance, seeds, published = _quality(result, query)
+    weights = config.get("ranking", {})
+    freshness_days = 0.0
+    if published > 0:
+        freshness_days = max(0.0, (time.time() - published) / 86400)
+    return (
+        relevance * float(weights.get("relevance", 1000))
+        + max(0, seeds) * float(weights.get("seeders", 10))
+        - freshness_days * float(weights.get("freshness", 1))
+    )
+
+
+def _safe_result(result: Dict[str, Any]) -> Dict[str, Any]:
+    for key in ("link", "name", "engine_url", "desc_link"):
+        result[key] = str(result.get(key, "")).replace("|", "%7C").replace("\n", " ")
+    for key in ("size", "seeds", "leech", "pub_date"):
+        if result.get(key) in (None, ""):
+            result[key] = -1
+    return result
+
+
+def _merge_magnets(primary: str, alternatives: Iterable[str]) -> str:
+    if not primary.startswith("magnet:?"):
+        return primary
+    parsed = urllib.parse.parse_qsl(
+        urllib.parse.urlsplit(primary).query, keep_blank_values=True
+    )
+    existing_trackers = {value for key, value in parsed if key == "tr"}
+    for alternative in alternatives:
+        if not alternative.startswith("magnet:?"):
+            continue
+        for key, value in urllib.parse.parse_qsl(
+            urllib.parse.urlsplit(alternative).query, keep_blank_values=True
+        ):
+            if key == "tr" and value not in existing_trackers:
+                parsed.append((key, value))
+                existing_trackers.add(value)
+    return "magnet:?" + urllib.parse.urlencode(parsed)
+
+
+def _request_options(source: Mapping[str, Any]) -> Tuple[int, float]:
+    return _integer(source.get("_retries"), 0), float(source.get("_backoff", 0.0))
+
+
+def _torznab(source: Mapping[str, Any], query: str, category: str, timeout: float) -> List[Dict[str, Any]]:
+    parameters = [
+        ("t", "search"),
+        ("q", urllib.parse.unquote_plus(query)),
+        ("limit", str(_integer(source.get("_limit"), 100))),
+        ("extended", "1"),
+    ]
+    api_key = str(source.get("api_key", "")).strip()
+    if api_key and api_key != "YOUR_API_KEY_HERE":
+        parameters.append(("apikey", api_key))
+    categories = CATEGORIES.get(category, ())
+    if categories:
+        parameters.append(("cat", ",".join(categories)))
+    url = _append_query(str(source["url"]), parameters)
+    retries, backoff = _request_options(source)
+    root = ET.fromstring(_request_text(url, timeout, retries=retries, backoff=backoff))
+    results: List[Dict[str, Any]] = []
+    for item in root.findall(".//item"):
+        title = _text(item.find("title"))
+        link = _attr(item, "magneturl") or _text(item.find("link"))
+        if not title or not link:
+            continue
+        seeds = _integer(_attr(item, "seeders"))
+        peers = _integer(_attr(item, "peers"))
+        leechers = peers - seeds if peers >= 0 and seeds >= 0 else _integer(_attr(item, "leechers"))
+        size = _integer(_text(item.find("size")), _integer(_attr(item, "size")))
+        desc = _text(item.find("comments")) or _text(item.find("guid")) or str(source["url"])
+        results.append(
+            {
+                "link": link,
+                "name": title,
+                "size": f"{size} B" if size >= 0 else -1,
+                "seeds": seeds,
+                "leech": leechers,
+                "engine_url": str(source["url"]),
+                "desc_link": desc,
+                "pub_date": _timestamp(_text(item.find("pubDate"))),
+                "_source": str(source.get("name", "Torznab")),
+            }
+        )
+    return results
+
+
+def _prowlarr(source: Mapping[str, Any], query: str, category: str, timeout: float) -> List[Dict[str, Any]]:
+    parameters = [
+        ("query", urllib.parse.unquote_plus(query)),
+        ("type", "search"),
+        ("limit", str(_integer(source.get("_limit"), 100))),
+    ]
+    categories = CATEGORIES.get(category, ())
+    for category_id in categories:
+        parameters.append(("categories", category_id))
+    url = _append_query(str(source["url"]), parameters)
+    api_key = str(source.get("api_key", "")).strip()
+    headers = {"X-Api-Key": api_key} if api_key and api_key != "YOUR_API_KEY_HERE" else {}
+    retries, backoff = _request_options(source)
+    payload: Any = json.loads(
+        _request_text(url, timeout, headers=headers, retries=retries, backoff=backoff)
+    )
+    items = cast(
+        List[Dict[str, Any]],
+        payload if isinstance(payload, list) else payload.get("records", []),
+    )
+    results: List[Dict[str, Any]] = []
+    for item in items:
+        title = str(item.get("title", ""))
+        link = str(item.get("magnetUrl") or item.get("downloadUrl") or "")
+        if not title or not link:
+            continue
+        results.append(
+            {
+                "link": link,
+                "name": title,
+                "size": f"{_integer(item.get('size'))} B" if item.get("size") else -1,
+                "seeds": _integer(item.get("seeders")),
+                "leech": _integer(item.get("leechers")),
+                "engine_url": str(source["url"]),
+                "desc_link": str(item.get("infoUrl") or item.get("guid") or source["url"]),
+                "pub_date": _timestamp(item.get("publishDate")),
+                "_source": str(item.get("indexer") or source.get("name", "Prowlarr")),
+            }
+        )
+    return results
+
+
+def _torrentscsv(source: Mapping[str, Any], query: str, _category: str, timeout: float) -> List[Dict[str, Any]]:
+    base_url = str(source["url"]).rstrip("/")
+    url = _append_query(
+        f"{base_url}/service/search",
+        (("size", "100"), ("q", urllib.parse.unquote_plus(query))),
+    )
+    retries, backoff = _request_options(source)
+    payload = cast(
+        Dict[str, Any],
+        json.loads(_request_text(url, timeout, retries=retries, backoff=backoff)),
+    )
+    results: List[Dict[str, Any]] = []
+    for item in cast(List[Dict[str, Any]], payload.get("torrents", [])):
+        info_hash = str(item.get("infohash", ""))
+        name = str(item.get("name", ""))
+        if not info_hash or not name:
+            continue
+        magnet = "magnet:?" + urllib.parse.urlencode(
+            {"xt": f"urn:btih:{info_hash}", "dn": name}
+        )
+        results.append(
+            {
+                "link": magnet,
+                "name": name,
+                "size": f"{_integer(item.get('size_bytes'))} B",
+                "seeds": _integer(item.get("seeders")),
+                "leech": _integer(item.get("leechers")),
+                "engine_url": base_url,
+                "desc_link": f"{base_url}/#/search/torrent/{urllib.parse.quote_plus(name)}/1",
+                "pub_date": _integer(item.get("created_unix")),
+                "_source": str(source.get("name", "Torrents.csv")),
+            }
+        )
+    return results
+
+
+ADAPTERS = {"torznab": _torznab, "prowlarr": _prowlarr, "torrentscsv": _torrentscsv}
+
+
+def _search_with_expansion(
+    adapter: Callable[
+        [Mapping[str, Any], str, str, float], List[Dict[str, Any]]
+    ],
+    source: Mapping[str, Any],
+    query: str,
+    category: str,
+    timeout: float,
+) -> List[Dict[str, Any]]:
+    variants = _query_variants(query)
+    adaptive = source.get("_adaptive", {})
+    enabled = bool(adaptive.get("enabled", True))
+    target = max(1, _integer(adaptive.get("target_unique_results"), 75))
+    extras = max(0, _integer(adaptive.get("max_extra_queries"), 3))
+    selected = variants[: 1 + extras] if enabled else variants[:1]
+    unique: Dict[str, Dict[str, Any]] = {}
+    for number, variant in enumerate(selected):
+        if number > 0 and len(unique) >= target:
+            break
+        for result in adapter(source, variant, category, timeout):
+            key = _dedupe_key(result)
+            previous = unique.get(key)
+            if previous is None or _quality(result, query) > _quality(previous, query):
+                unique[key] = result
+    return list(unique.values())
+
+
+class torrenthunter:
+    url = "https://github.com/qbittorrent/search-plugins"
+    name = "TorrentHunter"
+    supported_categories = {name: name for name in CATEGORIES}
+
+    def download_torrent(self, info: str) -> None:
+        if info.startswith("magnet:?"):
+            print(f"{info} {info}")
+        else:
+            print(download_file(info))
+
+    def search(self, what: str, cat: str = "all") -> None:
+        config = _load_config()
+        state = _load_state()
+        now = time.time()
+        category = cat.lower() if cat.lower() in CATEGORIES else "all"
+        enabled: List[Dict[str, Any]] = []
+        for source in cast(List[Dict[str, Any]], config["sources"]):
+            if source.get("enabled", True) and source.get("type") in ADAPTERS:
+                enabled.append(dict(source))
+        if not enabled:
+            _stderr(f"no sources enabled; edit {CONFIG_PATH}")
+            return
+
+        timeout = max(1.0, float(config.get("timeout_seconds", 12)))
+        per_source = max(1, int(config.get("max_results_per_source", 100)))
+        cache_ttl = max(0, int(config.get("cache_ttl_seconds", 300)))
+        failure_threshold = max(1, int(config.get("failure_threshold", 3)))
+        breaker_seconds = max(1, int(config.get("circuit_breaker_seconds", 300)))
+        for source in enabled:
+            source["_retries"] = max(0, int(config.get("retries", 2)))
+            source["_backoff"] = max(0.0, float(config.get("retry_backoff_seconds", 0.4)))
+            source["_limit"] = per_source
+            source["_adaptive"] = config.get("adaptive_search", {})
+
+        collected: List[Dict[str, Any]] = []
+        pending: List[Tuple[Dict[str, Any], str, str]] = []
+        stale: Dict[str, List[Dict[str, Any]]] = {}
+        for source in enabled:
+            source_key = _source_id(source)
+            cache_key = _cache_key(source, what, category)
+            cache_entry = cast(Dict[str, Any], state["cache"].get(cache_key, {}))
+            cached_results = cache_entry.get("results", [])
+            if isinstance(cached_results, list):
+                cached_results = cast(List[Dict[str, Any]], cached_results)
+                stale[source_key] = cached_results
+            else:
+                cached_results = []
+            if cached_results and now - float(cache_entry.get("time", 0)) <= cache_ttl:
+                collected.extend(cached_results[:per_source])
+                continue
+            health = state["sources"].get(source_key, {})
+            if float(health.get("retry_after", 0)) > now:
+                _stderr(f"{source.get('name', 'source')} temporarily skipped after repeated failures")
+                if config.get("stale_cache_on_error", True):
+                    collected.extend(stale.get(source_key, [])[:per_source])
+                continue
+            pending.append((source, source_key, cache_key))
+
+        worker_count = max(1, min(int(config.get("max_workers", 8)), len(pending) or 1))
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            futures = {
+                executor.submit(
+                    _search_with_expansion,
+                    ADAPTERS[str(source["type"])],
+                    source,
+                    what,
+                    category,
+                    max(1.0, float(source.get("timeout_seconds", timeout))),
+                ): (source, source_key, cache_key)
+                for source, source_key, cache_key in pending
+            }
+            for future in as_completed(futures):
+                source, source_key, cache_key = futures[future]
+                try:
+                    results = future.result()[:per_source]
+                    collected.extend(results)
+                    state["sources"][source_key] = {
+                        "failures": 0,
+                        "retry_after": 0,
+                        "last_success": int(now),
+                    }
+                    state["cache"][cache_key] = {"time": int(now), "results": results}
+                except (OSError, ValueError, KeyError, ET.ParseError, urllib.error.URLError) as exc:
+                    _stderr(f"{source.get('name', 'source')} failed: {exc}")
+                    health = state["sources"].setdefault(source_key, {})
+                    failures = int(health.get("failures", 0)) + 1
+                    health.update({"failures": failures, "last_failure": int(now)})
+                    if failures >= failure_threshold:
+                        health["retry_after"] = int(now + breaker_seconds)
+                    if config.get("stale_cache_on_error", True):
+                        collected.extend(stale.get(source_key, [])[:per_source])
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    # One source must never break the others.
+                    _stderr(f"{source.get('name', 'source')} unexpected failure: {exc}")
+
+        oldest_cache = now - max(cache_ttl * 10, 86400)
+        state["cache"] = {
+            key: value
+            for key, value in state["cache"].items()
+            if float(value.get("time", 0)) >= oldest_cache
+        }
+        _save_state(state)
+
+        grouped: Dict[str, List[Dict[str, Any]]] = {}
+        for result in collected:
+            grouped.setdefault(_dedupe_key(result), []).append(result)
+
+        unique: List[Dict[str, Any]] = []
+        for duplicates in grouped.values():
+            best = max(duplicates, key=lambda item: _score(item, what, config))
+            best["link"] = _merge_magnets(
+                str(best["link"]), (str(item["link"]) for item in duplicates)
+            )
+            sources = sorted({str(item.get("_source", "source")) for item in duplicates})
+            best["_source"] = ", ".join(sources)
+            unique.append(best)
+
+        minimum_seeders = int(config.get("minimum_seeders", 0))
+        maximum_age_days = int(config.get("maximum_age_days", 0))
+        filtered: List[Dict[str, Any]] = []
+        for result in unique:
+            seeds = _integer(result.get("seeds"))
+            published = _integer(result.get("pub_date"))
+            if 0 <= seeds < minimum_seeders:
+                continue
+            if maximum_age_days > 0 and published > 0:
+                if now - published > maximum_age_days * 86400:
+                    continue
+            filtered.append(result)
+
+        ordered = sorted(
+            filtered, key=lambda item: _score(item, what, config), reverse=True
+        )
+        for result in ordered:
+            if config.get("show_source_in_name", True):
+                result["name"] = f"{result['name']} [{result.pop('_source', 'source')}]"
+            else:
+                result.pop("_source", None)
+            with PRINT_LOCK:
+                prettyPrinter(cast(SearchResults, _safe_result(result)))

--- a/nova3/engines/versions.txt
+++ b/nova3/engines/versions.txt
@@ -6,3 +6,4 @@ solidtorrents: 2.8
 torlock: 2.28
 torrentproject: 1.91
 torrentscsv: 1.8
+torrenthunter: 0.20

--- a/nova3/tests/test_torrenthunter.py
+++ b/nova3/tests/test_torrenthunter.py
@@ -1,0 +1,281 @@
+import json
+import unittest
+import urllib.parse
+from typing import Any, Dict, List, Mapping
+from unittest import mock
+
+from engines import torrenthunter as plugin
+
+# pyright: reportPrivateUsage=false
+
+
+# pylint: disable=protected-access
+
+PRINTED: List[Dict[str, Any]] = []
+
+
+TORZNAB_XML = """\
+<rss xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <item>
+      <title>Ubuntu 24.04 Desktop</title>
+      <link>https://example.test/ubuntu.torrent</link>
+      <guid>https://example.test/details/1</guid>
+      <size>5000000000</size>
+      <pubDate>Tue, 23 Jul 2024 12:00:00 +0000</pubDate>
+      <torznab:attr name="magneturl"
+        value="magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567&amp;dn=Ubuntu" />
+      <torznab:attr name="seeders" value="42" />
+      <torznab:attr name="peers" value="50" />
+    </item>
+  </channel>
+</rss>
+"""
+
+
+class TorrentHunterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        PRINTED.clear()
+        printer = mock.patch.object(plugin, "prettyPrinter", PRINTED.append)
+        printer.start()
+        self.addCleanup(printer.stop)
+
+    def test_parses_torznab_result_and_category(self) -> None:
+        source = {
+            "name": "Test Indexer",
+            "type": "torznab",
+            "url": "https://example.test/api?existing=yes",
+            "api_key": "secret",
+        }
+        with mock.patch.object(plugin, "_request_text", return_value=TORZNAB_XML) as request:
+            results = plugin._torznab(source, "ubuntu+linux", "movies", 5)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["seeds"], 42)
+        self.assertEqual(results[0]["leech"], 8)
+        self.assertEqual(results[0]["size"], "5000000000 B")
+        requested_url = request.call_args.args[0]
+        self.assertIn("existing=yes", requested_url)
+        self.assertIn("apikey=secret", requested_url)
+        self.assertIn("cat=2000", requested_url)
+        self.assertIn("q=ubuntu+linux", requested_url)
+
+    def test_dedupe_prefers_better_seeded_duplicate(self) -> None:
+        first = {
+            "link": "magnet:?xt=urn:btih:0123456789ABCDEF0123456789ABCDEF01234567",
+            "name": "Ubuntu",
+            "size": "100 B",
+            "seeds": 2,
+            "pub_date": 1,
+        }
+        second = dict(first, seeds=20)
+        self.assertEqual(plugin._dedupe_key(first), plugin._dedupe_key(second))
+        self.assertGreater(plugin._quality(second, "ubuntu"), plugin._quality(first, "ubuntu"))
+
+    def test_search_isolates_source_failure_and_prints_success(self) -> None:
+        config = dict(plugin.DEFAULT_CONFIG)
+        config["sources"] = [
+            {"name": "Broken", "type": "torznab", "url": "https://broken.test"},
+            {"name": "Working", "type": "torrentscsv", "url": "https://working.test"},
+        ]
+        item = {
+            "link": "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567",
+            "name": "Ubuntu",
+            "size": "100 B",
+            "seeds": 5,
+            "leech": 1,
+            "engine_url": "https://working.test",
+            "desc_link": "https://working.test/1",
+            "pub_date": 10,
+            "_source": "Working",
+        }
+
+        def adapter(
+            source: Mapping[str, Any], *_args: Any
+        ) -> List[Dict[str, Any]]:
+            if source["name"] == "Broken":
+                raise OSError("offline")
+            return [dict(item)]
+
+        with mock.patch.object(
+            plugin, "_load_config", return_value=config
+        ), mock.patch.object(
+                plugin, "_load_state", return_value={"sources": {}, "cache": {}}
+        ), mock.patch.object(plugin, "_save_state"), mock.patch.dict(
+            plugin.ADAPTERS,
+            {"torznab": adapter, "torrentscsv": adapter},
+            clear=True,
+        ):
+            plugin.torrenthunter().search("ubuntu")
+
+        self.assertEqual(len(PRINTED), 1)
+        self.assertEqual(PRINTED[0]["name"], "Ubuntu [Working]")
+
+    def test_example_configuration_is_valid(self) -> None:
+        self.assertTrue(plugin.DEFAULT_CONFIG["sources"])
+        self.assertTrue(
+            any(source["enabled"] for source in plugin.DEFAULT_CONFIG["sources"])
+        )
+        self.assertEqual(
+            next(
+                source
+                for source in plugin.DEFAULT_CONFIG["sources"]
+                if source["name"] == "Prowlarr"
+            )["type"],
+            "prowlarr",
+        )
+
+    def test_parses_prowlarr_json_and_uses_api_key_header(self) -> None:
+        source = {
+            "name": "Prowlarr",
+            "type": "prowlarr",
+            "url": "http://127.0.0.1:9696/api/v1/search",
+            "api_key": "secret",
+        }
+        payload = json.dumps(
+            [
+                {
+                    "title": "Ubuntu Desktop",
+                    "magnetUrl": "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567",
+                    "size": 100,
+                    "seeders": 9,
+                    "leechers": 2,
+                    "infoUrl": "https://example.test/details",
+                    "publishDate": "2024-07-23T12:00:00Z",
+                    "indexer": "Example",
+                }
+            ]
+        )
+        with mock.patch.object(plugin, "_request_text", return_value=payload) as request:
+            results = plugin._prowlarr(source, "ubuntu", "all", 5)
+
+        self.assertEqual(results[0]["_source"], "Example")
+        self.assertEqual(request.call_args.kwargs["headers"], {"X-Api-Key": "secret"})
+
+    def test_duplicate_magnets_merge_unique_trackers(self) -> None:
+        primary = (
+            "magnet:?xt=urn%3Abtih%3A0123456789abcdef0123456789abcdef01234567"
+            "&tr=udp%3A%2F%2Ftracker-one"
+        )
+        alternative = (
+            "magnet:?xt=urn%3Abtih%3A0123456789abcdef0123456789abcdef01234567"
+            "&tr=udp%3A%2F%2Ftracker-two"
+        )
+        merged = plugin._merge_magnets(primary, [alternative, primary])
+        query = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(merged).query))
+        self.assertIn("xt", query)
+        self.assertEqual(merged.count("tr="), 2)
+
+    def test_fresh_cache_avoids_second_network_search(self) -> None:
+        config = dict(plugin.DEFAULT_CONFIG)
+        config["sources"] = [
+            {"name": "Working", "type": "torrentscsv", "url": "https://working.test"}
+        ]
+        state: Dict[str, Any] = {"sources": {}, "cache": {}}
+        item = {
+            "link": "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567",
+            "name": "Ubuntu",
+            "size": "100 B",
+            "seeds": 5,
+            "leech": 1,
+            "engine_url": "https://working.test",
+            "desc_link": "https://working.test/1",
+            "pub_date": 10,
+            "_source": "Working",
+        }
+        adapter = mock.Mock(return_value=[item])
+        with mock.patch.object(
+            plugin, "_load_config", return_value=config
+        ), mock.patch.object(
+            plugin, "_load_state", return_value=state
+        ), mock.patch.object(
+            plugin, "_save_state"
+        ), mock.patch.dict(
+            plugin.ADAPTERS, {"torrentscsv": adapter}, clear=True
+        ):
+            plugin.torrenthunter().search("ubuntu")
+            plugin.torrenthunter().search("ubuntu")
+
+        self.assertEqual(adapter.call_count, 1)
+
+    def test_query_variants_normalize_and_relax_release_terms(self) -> None:
+        variants = plugin._query_variants(
+            "Example.Show.S01E02.2025.1080p.WEB-DL.x265"
+        )
+        self.assertEqual(variants[0], "Example.Show.S01E02.2025.1080p.WEB-DL.x265")
+        self.assertIn("Example Show S01E02 2025 1080p WEB-DL x265", variants)
+        self.assertTrue(any("1x02" in variant for variant in variants))
+        self.assertTrue(any("1080p" not in variant and "x265" not in variant for variant in variants))
+        self.assertTrue(any("2025" not in variant for variant in variants))
+
+    def test_adaptive_search_stops_when_exact_query_meets_target(self) -> None:
+        calls: List[str] = []
+
+        def adapter(
+            _source: Mapping[str, Any],
+            query: str,
+            _category: str,
+            _timeout: float,
+        ) -> List[Dict[str, Any]]:
+            calls.append(query)
+            return [
+                {
+                    "link": f"magnet:?xt=urn:btih:{number:040x}",
+                    "name": f"Example {number}",
+                    "size": "1 B",
+                    "seeds": 1,
+                    "pub_date": 1,
+                }
+                for number in range(3)
+            ]
+
+        source = {
+            "_adaptive": {
+                "enabled": True,
+                "target_unique_results": 3,
+                "max_extra_queries": 3,
+            }
+        }
+        results = plugin._search_with_expansion(
+            adapter, source, "Example.Show.1080p", "all", 5
+        )
+        self.assertEqual(len(results), 3)
+        self.assertEqual(calls, ["Example.Show.1080p"])
+
+    def test_adaptive_search_expands_when_results_are_scarce(self) -> None:
+        calls: List[str] = []
+
+        def adapter(
+            _source: Mapping[str, Any],
+            query: str,
+            _category: str,
+            _timeout: float,
+        ) -> List[Dict[str, Any]]:
+            calls.append(query)
+            number = len(calls)
+            return [
+                {
+                    "link": f"magnet:?xt=urn:btih:{number:040x}",
+                    "name": query,
+                    "size": "1 B",
+                    "seeds": 1,
+                    "pub_date": 1,
+                }
+            ]
+
+        source = {
+            "_adaptive": {
+                "enabled": True,
+                "target_unique_results": 10,
+                "max_extra_queries": 2,
+            }
+        }
+        plugin._search_with_expansion(
+            adapter, source, "Example.Movie.2025.1080p", "movies", 5
+        )
+        self.assertEqual(len(calls), 3)
+        self.assertNotEqual(calls[0], calls[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nova3/tests/test_torrenthunter.py
+++ b/nova3/tests/test_torrenthunter.py
@@ -208,6 +208,64 @@ class TorrentHunterTests(unittest.TestCase):
         self.assertTrue(any("1080p" not in variant and "x265" not in variant for variant in variants))
         self.assertTrue(any("2025" not in variant for variant in variants))
 
+    def test_query_variants_remove_low_information_title_words(self) -> None:
+        variants = plugin._query_variants("The Incredibles")
+        self.assertEqual(variants[0], "The Incredibles")
+        self.assertIn("Incredibles", variants)
+
+    def test_fuzzy_title_similarity_tolerates_misspellings(self) -> None:
+        self.assertGreater(
+            plugin._fuzzy_title_similarity(
+                "The Incredibls 2004 1080p BluRay", "The Incredibles"
+            ),
+            0.9,
+        )
+        self.assertGreater(
+            plugin._fuzzy_title_similarity(
+                "Incredables 2004 WEB-DL", "The Incredibles"
+            ),
+            0.8,
+        )
+        self.assertLess(
+            plugin._fuzzy_title_similarity("Finding Nemo 2003", "The Incredibles"),
+            0.5,
+        )
+
+    def test_adaptive_search_requeries_inferred_spelling(self) -> None:
+        calls: List[str] = []
+
+        def adapter(
+            _source: Mapping[str, Any],
+            query: str,
+            _category: str,
+            _timeout: float,
+        ) -> List[Dict[str, Any]]:
+            calls.append(query)
+            if query == "The Incredibls":
+                return [
+                    {
+                        "link": f"magnet:?xt=urn:btih:{number:040x}",
+                        "name": f"The Incredibles 2004 release {number}",
+                        "size": "1 B",
+                        "seeds": 1,
+                        "pub_date": 1,
+                    }
+                    for number in range(2)
+                ]
+            return []
+
+        source = {
+            "_adaptive": {
+                "enabled": True,
+                "target_unique_results": 10,
+                "max_extra_queries": 1,
+            }
+        }
+        plugin._search_with_expansion(
+            adapter, source, "The Incredibls", "movies", 5
+        )
+        self.assertEqual(calls, ["The Incredibls", "The Incredibles"])
+
     def test_adaptive_search_stops_when_exact_query_meets_target(self) -> None:
         calls: List[str] = []
 


### PR DESCRIPTION
## What changed

- add the standalone TorrentHunter qBittorrent search engine
- add direct Torrents.csv, generic Torznab, Jackett, and Prowlarr adapters
- add bounded fuzzy title matching, stop-word handling, and adaptive spelling correction
- add adaptive query expansion, info-hash deduplication, ranking, caching, retries, and circuit breaking
- register engine version `0.20`
- add focused parser, configuration, caching, deduplication, fuzzy-matching, and adaptive-search tests

## Why

TorrentHunter provides a resilient metasearch layer while remaining useful
without optional local services. It uses only the Python standard library and
follows qBittorrent's single-file plugin contract.

## Installation and optional configuration

Download
[`torrenthunter.py`](https://raw.githubusercontent.com/ScoobyChris/TorrentHunter/agent/add-torrenthunter/nova3/engines/torrenthunter.py),
then in qBittorrent open **Search plugins… → Install a new one → Local file**
and select it.

The plugin works immediately using its embedded defaults, which enable the
public Torrents.csv source. **No JSON file is required or included in this PR.**

Prowlarr and Jackett are optional. To enable either service:

1. Find qBittorrent's installed `nova3/engines/torrenthunter.py`.
2. Create `torrenthunter.json` in that same directory.
3. Copy the relevant source entry from `DEFAULT_CONFIG` in `torrenthunter.py`.
4. Replace `YOUR_API_KEY_HERE` with the API key from your own local service and
   set `"enabled": true`.

For example:

```json
{
  "sources": [
    {
      "name": "Prowlarr",
      "type": "prowlarr",
      "url": "http://127.0.0.1:9696/api/v1/search",
      "api_key": "YOUR_API_KEY_HERE",
      "enabled": true
    }
  ]
}
```

Users should never publish `torrenthunter.json` when it contains a real API
key.

## User impact

Users receive concurrent searches, normalized results, typo-tolerant title
matching, duplicate suppression, relevance ranking, and graceful handling of
slow or failing sources. Queries remain bounded to avoid excessive indexer
load.

## Validation

- pytest: 13 passed
- MyPy: clean
- Pyright: 0 errors
- Pyflakes: clean
- Bandit: no issues
- Pylint: 10.00/10
- pycodestyle: clean
- isort: clean
- byte compilation: successful
