### PR TITLE
Fix jackett engine crash when no indexers are available

### DIFF
--- a/nova3/engines/jackett.py
+++ b/nova3/engines/jackett.py
@@ -1,4 +1,4 @@
-# VERSION: 4.9
+# VERSION: 4.10
 # AUTHORS: Diego de las Heras (ngosang@hotmail.es)
 # CONTRIBUTORS: ukharley
 #               hannsen (github.com/hannsen)
@@ -141,6 +141,10 @@ class jackett:
         if self.thread_count > 1:
             args: List[Tuple[str, Union[List[str], None], str]] = []
             indexers = self.get_jackett_indexers(what)
+            if not indexers:
+                # get_jackett_indexers() already reported the error (or there
+                # are simply no configured indexers); nothing left to search.
+                return
             for indexer in indexers:
                 args.append((what, category, indexer))
             with Pool(min(len(indexers), self.thread_count)) as pool:


### PR DESCRIPTION
## Summary

Small fix to prevent an exception when no Jackett indexers are available.

`search()` could attempt to create a `multiprocessing.dummy.Pool(0)` when `get_jackett_indexers()` returned an empty list (for example, when no indexers are configured or Jackett is temporarily unavailable). This caused an unnecessary `ValueError` instead of failing gracefully.

The fix simply returns early when there are no indexers, avoiding the invalid pool creation.

Bumped `VERSION` to 4.10 to match repo conventions.

## Test plan

* Reproduced the original crash with `get_jackett_indexers()` returning `[]`.
* Confirmed the patched version returns cleanly without raising an exception.
* Verified that an empty indexer list can occur in normal usage (such as a temporary Jackett API failure).
