### PR TITLE
Update Snowfl plugin listing

### DIFF
--- a/wiki/Unofficial-search-plugins.mediawiki
+++ b/wiki/Unofficial-search-plugins.mediawiki
@@ -375,6 +375,13 @@ The minimum supported Python version (across all platforms) is specified at [htt
 | [https://raw.githubusercontent.com/LightDestory/qBittorrent-Search-Plugins/master/src/engines/snowfl.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]]]
 | ✔ qbt 4.3.x / Python 3.8.5 <br>**READ REPOSITORY NOTES**
 |-
+| [[https://www.google.com/s2/favicons?domain=snowfl.com#.png]] [https://snowfl.com Snowfl]
+| [https://github.com/ChocoTonic/snowfl ChocoTonic]
+| 2.1
+| 29/Jun<br>2026
+| [https://github.com/ChocoTonic/snowfl/releases/latest/download/snowfl.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]]]
+| ✔ qbt 5.2.x / Python 3.x
+|-
 | [[https://www.google.com/s2/favicons?domain=solidtorrents.to#.png]] [https://solidtorrents.to/ SolidTorrents.to]
 | [https://github.com/BurningMop/qBittorrent-Search-Plugins BurningMop]
 | 1.0


### PR DESCRIPTION
## Summary
- Update the Snowfl entry in the unofficial search plugins list from the old LightDestory plugin to ChocoTonic/snowfl
- Point the download link to the latest published snowfl.py release asset
- Refresh the listed version/date and qBittorrent compatibility note

References #435.

## Validation
- `python3 -m py_compile` against `https://github.com/ChocoTonic/snowfl/releases/latest/download/snowfl.py`
- `npx --yes wikilint --lint-config .github/workflows/helpers/pre-commit/.wikilint.json --strict --fix wiki/Unofficial-search-plugins.mediawiki`
- `git diff --check`

Note: `uvx pre-commit run --files wiki/Unofficial-search-plugins.mediawiki` could not complete because npm refused the markdownlint hook installation with `EALLOWGIT`; the relevant MediaWiki lint hook was run directly instead.