### PR TITLE
wiki: add TorrentClaw to unofficial search plugins

### DIFF
--- a/wiki/Unofficial-search-plugins.mediawiki
+++ b/wiki/Unofficial-search-plugins.mediawiki
@@ -459,6 +459,13 @@ The minimum supported Python version (across all platforms) is specified at [htt
 | [https://raw.githubusercontent.com/menegop/qbfrench/master/torrent9.py [[https://github.com/menegop/qbfrench/blob/master/Download.gif]]]
 | ✔ qbt 4.3.6 / Python 3.8
 |-
+| [[https://github.com/LightDestory/qBittorrent-Search-Plugins/raw/master/src/engines/torrentclaw.png]] [https://torrentclaw.com/ TorrentClaw]
+| [https://github.com/LightDestory/qBittorrent-Search-Plugins LightDestory]
+| 1.0
+| 16/Aug<br>2026
+| [https://raw.githubusercontent.com/LightDestory/qBittorrent-Search-Plugins/master/src/engines/torrentclaw.py [[https://raw.githubusercontent.com/Pireo/hello-world/master/Download.gif]]]
+| ✔ qbt 4.x / Python 3.10+ <br>Torznab aggregator (~10 sources). Free API key optional via TORRENTCLAW_API_KEY env var.
+|-
 | [[https://github.com/LightDestory/qBittorrent-Search-Plugins/raw/master/src/engines/torrentdownload.png]] [https://torrentdownload.info/ TorrentDownload]
 | [https://github.com/LightDestory/qBittorrent-Search-Plugins LightDestory]
 | 1.0


### PR DESCRIPTION
Adds TorrentClaw to the unofficial search plugins table, as instructed in #431.

TorrentClaw is a public Torznab aggregator (~10 sources: YTS, EZTV, Knaben, Bitmagnet, Torrentio, Torrents.csv, DonTorrent and others). The plugin queries the public JSON endpoint `/api/v1/search` — no scraping — and rebuilds magnet links locally from the returned `info_hash`, so it works without an account. An optional `TORRENTCLAW_API_KEY` env var gives server-built magnets and a higher rate limit.

The plugin and its icon are already hosted in the LightDestory repository (LightDestory/qBittorrent-Search-Plugins#36, merged), so the download link and favicon point to raw.githubusercontent.com — no Google favicon service is used.

Row inserted alphabetically between Torrent9 and TorrentDownload.

Tested with:

```
python3 nova2.py torrentclaw all    "the dark knight"
python3 nova2.py torrentclaw movies "matrix"
python3 nova2.py torrentclaw tv     "breaking bad"
```

qbt 4.x / Python 3.10+.
